### PR TITLE
a useful static file url-to-graph dot viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Viz.js</title>
+    <style>
+      #output svg { width: 100%; }
+    </style>
+  </head>
+  <body>
+
+    <div id="output"></div>
+    <pre><code id="source"></code></pre>
+    
+    <script src="viz.js"></script>
+    <script>
+
+    function get (url, callback) {
+      var xhr = window.ActiveXObject ? new ActiveXObject('Microsoft.XMLHTTP') : new XMLHttpRequest();
+      xhr.onreadystatechange = function() {
+        if (xhr.readyState === 4) {
+          if (callback) {
+            return callback(xhr.responseText);
+          }
+        }
+      };
+      xhr.open('GET', url, true);
+      return xhr.send();
+    }
+
+    var pairs = (location.hash || location.search).substr(1).split('&')
+    var args = {}
+    pairs.forEach(function (pair) {
+      var p = pair.split('=')
+      args[p[0]] = p[1]
+    })
+
+    function render (input, format, engine) {
+      if (!input) {
+        input = 'digraph { you -> got -> no -> input }'
+      }
+
+      var result = Viz(input, format, engine);
+      
+      if (format == "svg") {
+        document.getElementById("output").innerHTML = result;
+      } else {
+        document.getElementById("output").innerHTML = "";
+      }
+
+      document.getElementById("source").innerHTML = input
+    }
+
+    var format = args.format || 'svg'
+    var engine = args.engine || 'dot'
+
+    if (args.url) {
+      get(args.url, function (input) {
+        render(input, format, engine)
+      })
+    }
+    else if (args.src) {
+      render(args.src, format, engine)
+    }
+    else { render(null, format, engine) }
+
+    if (args.title) {
+      document.title = 'dot: ' + args.title
+    }
+    else if (args.url) {
+      document.title = 'dot: ' + args.url.split('/').filter(function (x) { return x }).slice(-1)[0]
+    }
+      
+    </script>
+    
+  </body>
+</html>


### PR DESCRIPTION
* People can link to it. For example: http://fiatjaf.alhur.es/viz.js/?url=https://fiatjaf-annex.s3.amazonaws.com/SHA256E-s1895--4d621b28b8477887eb3c4d2974ad868ffeb9ff4c31d334882d8095fa8bb78377.dot
* Invalid input gives a nice error: http://fiatjaf.alhur.es/viz.js/?url=http://google.com/search
* There are options for engines and layouts, just send `format` or `engine` or `title` in the query string.
* Works with a normal query string and a query string sent after the hash, as in `#url=http://example.com/graph.dot`