### PR TITLE
add test to confirm Viz.js can recover from an error

### DIFF
--- a/tests/input.js
+++ b/tests/input.js
@@ -1,5 +1,22 @@
 QUnit.module("input");
 
+QUnit.test("recovers from an error", function(assert) {
+  var successRender = function() {
+    return Viz('digraph G { A -> "B" }', { format: "xdot" });
+  };
+  var failureRender = function() {
+    return Viz('digraph G { A -> "B }', { format: "xdot" });
+  };
+
+  var attempt1 = successRender();
+  assert.ok(attempt1.match(/digraph G/), "1: valid data succeeds");
+
+  assert.throws(failureRender, /error/, "2: invalid data fails");
+
+  var attempt3 = successRender();
+  assert.ok(attempt3.match(/digraph G/), "3: valid data succeeds again");
+});
+
 QUnit.test("result from first graph in input is returned for multiple invocations", function(assert) {
   var result = Viz("digraph A {} digraph B {}", { format: "xdot" });
   assert.ok(result.match(/digraph A/), "Result should contain \"digraph A\"");


### PR DESCRIPTION
I noticed an issue with 1.2.0, and I'm trying to help in the ways I'm able :) :tada: 

Viz.js 1.2.0 seems to stop working after it encounters an error. It may be related to `lastError`:
https://github.com/mdaines/viz.js/commit/60bc435028362576f540a6727cfc28b3688ed014#diff-012dd2b56a863a41776f3a519e6aaa56R19

This PR is me adding a test to demonstrate how to reproduce the issue. (Btw, by adding this test to the top of the `input.js` broke the rest of the tests in that file, because of this issue.)