### PR TITLE
Correctly forward errors that not derived from Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 script:
   - docker exec -it emscripten make deps all
   - node test-browser/runner --matrix test-browser/all.json
-  - node_modules/.bin/mocha test-node
+  - npm test
 
 before_deploy:
   - rvm $(travis_internal_ruby) do ruby -S gem install octokit git

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "path": false,
     "crypto": false
   },
+  "scripts": {
+    "test": "mocha test-node"
+  },
   "author": "Mike Daines <mdaines@fastmail.com>",
   "license": "MIT",
   "bugs": {

--- a/src/boilerplate/post-module.js
+++ b/src/boilerplate/post-module.js
@@ -36,7 +36,10 @@ if (typeof importScripts === "function") {
       var result = render(instance, src, options);
       postMessage({ id: id, result: result });
     } catch (error) {
-      postMessage({ id: id, error: { message: error.message, fileName: error.fileName, lineNumber: error.lineNumber } });
+      var error = error instanceof Error
+        ? { message: error.message, fileName: error.fileName, lineNumber: error.lineNumber }
+        : { message: error.toString() };
+      postMessage({ id: id, error: error });
     }
   }
 }

--- a/test-node/render.js
+++ b/test-node/render.js
@@ -23,3 +23,27 @@ it('should render a graph using the Module and render functions exported by the 
     assert.ok(result);
   });
 });
+
+it('should throw descriptive error when not enough memory allocated', function() {
+  let worker = new Worker(path.resolve(__dirname, '../full.render.js'));
+  let viz = new Viz({ worker });
+  let dot = 'digraph {';
+  for (let i = 0; i < 50000; ++i) {
+    dot += `node${i} -> node${i + 1};`;
+  }
+  dot += '}';
+
+  return viz.renderString(dot).then(
+    () => {
+     worker.terminate();
+     assert.fail('should throw');
+    },
+    error => {
+      worker.terminate();
+      assert(
+        /Cannot enlarge memory arrays/.test(error.message),
+        'should return descriptive error',
+      );
+    },
+  );
+});


### PR DESCRIPTION
When Emscripten can't allocate memory it throws string with the error message but `viz.js` expects that `Emscripten` always throws objects derived from `Error`.
I also add `test` script so it's easier to do local testing during development.