### PR TITLE
Update Graphviz to 8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Update Graphviz to 8.1.0.
+
 * Export the Graphviz version, supported formats, and supported engines as constants generated at build time.
 
 * Include an ES module build as well as UMD.

--- a/src/module/Dockerfile
+++ b/src/module/Dockerfile
@@ -8,10 +8,10 @@ RUN mkdir -p expat && tar -zxf ./expat.tar.gz --strip-components 1 --directory e
 RUN cd expat && emconfigure ./configure --host=wasm32 --disable-shared --prefix="${PREFIX}" --libdir="${PREFIX}/lib" CFLAGS="-Oz" CXXFLAGS="-Oz"
 RUN cd expat/lib && emmake make all install
 
-ADD "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/8.0.5/graphviz-8.0.5.tar.gz" ./graphviz.tar.gz
+ADD "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/8.1.0/graphviz-8.1.0.tar.gz" ./graphviz.tar.gz
 
 RUN mkdir -p graphviz && tar -zxf ./graphviz.tar.gz --strip-components 1 --directory graphviz
-RUN cd graphviz && emconfigure ./configure --host=wasm32 --disable-ltdl --prefix="${PREFIX}" --libdir="${PREFIX}/lib" CFLAGS="-Oz" CXXFLAGS="-Oz"
+RUN cd graphviz && emconfigure ./configure --host=wasm32 --disable-ltdl --prefix="${PREFIX}" --libdir="${PREFIX}/lib" EXPAT_CFLAGS="-I${PREFIX}/include" EXPAT_LIBS="-L${PREFIX}/lib -lexpat" CFLAGS="-Oz" CXXFLAGS="-Oz"
 RUN cd graphviz/lib && emmake make install
 RUN cd graphviz/plugin && emmake make install
 

--- a/test/standalone.test.mjs
+++ b/test/standalone.test.mjs
@@ -5,7 +5,7 @@ import { JSDOM } from "jsdom";
 describe("standalone", function() {
   describe("graphvizVersion", function() {
     it("returns the Graphviz version", function() {
-      assert.strictEqual(Viz.graphvizVersion, "8.0.5");
+      assert.strictEqual(Viz.graphvizVersion, "8.1.0");
     });
   });
 
@@ -308,7 +308,7 @@ describe("standalone", function() {
 
     describe("graphvizVersion", function() {
       it("returns the Graphviz version", function() {
-        assert.strictEqual(viz.graphvizVersion, "8.0.5");
+        assert.strictEqual(viz.graphvizVersion, "8.1.0");
       });
     });
 


### PR DESCRIPTION
EXPAT_CFLAGS and EXPAT_LIBS are specified explicitly. Graphviz now uses pkg-config to find these, but that doesn't work in this particular case for some reason, even though emconfigure is supposed to set things up so that pkg-config can be called.

Relevant Graphviz commit: 4d530ac825ddfba3d0b0c130aa0cacf2801e80fb