### PR TITLE
Correct letter pattern

### DIFF
--- a/packages/lang-dot/src/dot.grammar
+++ b/packages/lang-dot/src/dot.grammar
@@ -111,7 +111,7 @@ ConcatString {
   blockCommentRest { ![*] blockCommentRest | "*" blockCommentAfterStar }
   blockCommentAfterStar { "/" | "*" blockCommentAfterStar | ![/*] blockCommentRest }
   
-  letter { $[A-Za-z_\u{200}-\u{377}] }
+  letter { $[A-Za-z_$\u{80}-\u{10ffff}] }
   
   digit { $[0-9] }
   

--- a/packages/lang-dot/test/graph.txt
+++ b/packages/lang-dot/test/graph.txt
@@ -176,6 +176,27 @@ Graph(Header(...), Body(
 ))
 
 
+# Names
+
+graph {
+  a
+  A_1
+  café
+   
+  図
+}
+
+==>
+
+Graph(Header(...), Body(
+  SimpleStatement(Node(Name(...))),
+  SimpleStatement(Node(Name(...))),
+  SimpleStatement(Node(Name(...))),
+  SimpleStatement(Node(Name(...))),
+  SimpleStatement(Node(Name(...)))
+))
+
+
 # Numbers
 
 graph 123 {


### PR DESCRIPTION
This previously copied the values from the Graphviz DOT lexer. That didn't actually work, since those are expressed in octal, and also don't refer to Unicode code points. According to [a comment in the lexer](https://gitlab.com/graphviz/graphviz/-/blob/fc79265f1da7f77aa93294776747056cbe595ee2/lib/cgraph/scan.l#L169-175), Graphviz will accept ASCII letters, underscore, and all non-ASCII characters for its "LETTER" class. (Non-ASCII characters in this case starts at 0200 or 0x80, non-breaking space.)