### PR TITLE
Object input and default attributes

### DIFF
--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Accept default attributes for graphs, nodes, and edges in render options. This is similar to the -G, -N, -E options provided by the Graphviz command-line.
+
+  Setting the default shape for nodes:
+
+    viz.render("digraph { a -> b }", { defaultAttributes: { node: { shape: "circle" } } });
+  
+  These attributes take precedence over default attributes specified in string and object input.
+
 * Accept an object that represents a graph as input for render(). This is a JSON object similar in structure to the Graphviz DOT syntax.
 
   Rendering with an object:

--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+* Accept an object that represents a graph as input for render(). This is a JSON object similar in structure to the Graphviz DOT syntax.
+
+  Rendering with an object:
+  
+    // DOT: digraph { a -> b }
+    viz.render({ directed: true, edges: [{ tail: "a", head: "b" }] });
+    
+  Another example:
+  
+    viz.render({
+      directed: true,
+      defaultAttributes: {
+        node: {
+          shape: "circle"
+        }
+      },
+      nodes: [
+        { name: "a", attributes: { label: "A", color: "red" } },
+      ],
+      edges: [
+        { tail: "a", head: "b" },
+      ],
+      subgraphs: [
+        {
+          name: "cluster_1",
+          nodes: [
+            { name: "b", attributes: { label: "B", color: "blue" } }
+          ]
+        }
+      ]
+    });
+  
+  HTML-like labels are not yet supported. Edge ports can be specified using the headport and tailport attributes.
+
 * Update Emscripten SDK to 3.1.43.
 
 ## 3.1.0

--- a/packages/viz/src/viz.mjs
+++ b/packages/viz/src/viz.mjs
@@ -153,6 +153,10 @@ function renderInput(module, input, options) {
       };
     }
 
+    if (options.defaultAttributes) {
+      setDefaultAttributes(module, graphPointer, options.defaultAttributes);
+    }
+
     module.ccall("viz_set_y_invert", "number", ["number"], [options.yInvert ? 1 : 0]);
 
     resultPointer = module.ccall("viz_render_graph", "number", ["number", "string", "string"], [graphPointer, options.format, options.engine]);

--- a/packages/viz/test/manual/instance-reuse.mjs
+++ b/packages/viz/test/manual/instance-reuse.mjs
@@ -1,16 +1,18 @@
 import { instance } from "../../src/standalone.mjs";
-import { makeGraph } from "./utils.mjs";
+import { randomGraph, dotStringify } from "./utils.mjs";
 
-const basicGraph = makeGraph(100, 10);
-const multipleGraphs = `${basicGraph}${basicGraph}`;
+const basicObject = randomGraph(100, 10);
+const basicString = dotStringify(basicObject);
+const multipleGraphs = `${basicString}${basicString}`;
 const invalidInput = "graph {";
 
 const tests = [
-  { label: "valid input", fn: viz => viz.render(basicGraph) },
+  { label: "valid input", fn: viz => viz.render(basicString) },
+  { label: "object input", fn: viz => viz.render(basicObject) },
   { label: "valid input containing multiple graphs", fn: viz => viz.render(multipleGraphs) },
   { label: "invalid input", fn: viz => viz.render(invalidInput) },
-  { label: "invalid layout engine option", fn: viz => viz.render(basicGraph, { engine: "invalid" }) },
-  { label: "invalid format option", fn: viz => viz.render(basicGraph, { format: "invalid" }) },
+  { label: "invalid layout engine option", fn: viz => viz.render(basicString, { engine: "invalid" }) },
+  { label: "invalid format option", fn: viz => viz.render(basicString, { format: "invalid" }) },
   { label: "list layout engines", fn: viz => viz.engines },
   { label: "list formats", fn: viz => viz.formats }
 ];
@@ -23,12 +25,12 @@ for (const { label, fn } of tests) {
   let previous = 0;
 
   for (let i = 0; i < 10000; i++) {
-    fn(viz);
+    const result = fn(viz);
 
     const current = process.memoryUsage.rss();
 
     if (i % 1000 == 999) {
-      console.log(`count: ${i+1}`, `rss: ${current}`, previous > 0 ? `change: ${current - previous}` : "");
+      console.log(`output length: ${result.output?.length}, count: ${i+1}`, `rss: ${current}`, previous > 0 ? `change: ${current - previous}` : "");
       previous = current;
     }
   }

--- a/packages/viz/test/manual/performance-object.mjs
+++ b/packages/viz/test/manual/performance-object.mjs
@@ -1,0 +1,44 @@
+import { instance } from "../../src/standalone.mjs";
+import { randomGraph, dotStringify } from "./utils.mjs";
+
+function measure(operation, timeLimit) {
+  let callCount = 0;
+
+  const startTime = performance.now();
+
+  while (performance.now() - startTime < timeLimit) {
+    operation();
+    callCount++;
+  }
+
+  const stopTime = performance.now();
+  const duration = (stopTime - startTime) / 1000;
+  const speed = callCount / duration;
+
+  return `${callCount} in ${duration.toFixed(2)} s, ${speed.toFixed(2)} calls/s`
+}
+
+const tests = [
+  { nodeCount: 100, randomEdgeCount: 10 },
+  { nodeCount: 1000, randomEdgeCount: 50 },
+  { nodeCount: 1000, randomEdgeCount: 500 },
+  { nodeCount: 1000, randomEdgeCount: 1000 }
+];
+
+tests.forEach(test => {
+  test.input = randomGraph(test.nodeCount, test.randomEdgeCount);
+});
+
+const timeLimit = 5000;
+
+for (const { input, nodeCount, randomEdgeCount } of tests) {
+  const viz = await instance();
+  const result = measure(() => viz.render(dotStringify(input)), timeLimit);
+  console.log(`stringify, ${nodeCount} nodes, ${randomEdgeCount} edges: ${result}`);
+}
+
+for (const { input, nodeCount, randomEdgeCount } of tests) {
+  const viz = await instance();
+  const result = measure(() => viz.render(input), timeLimit);
+  console.log(`map, ${nodeCount} nodes, ${randomEdgeCount} edges: ${result}`);
+}

--- a/packages/viz/test/manual/performance-timing.mjs
+++ b/packages/viz/test/manual/performance-timing.mjs
@@ -1,5 +1,5 @@
 import { instance } from "../../src/standalone.mjs";
-import { makeGraph } from "./utils.mjs";
+import { randomGraph, dotStringify } from "./utils.mjs";
 
 const tests = [
   { nodeCount: 100, randomEdgeCount: 0 },
@@ -17,7 +17,7 @@ const timeLimit = 5000;
 
 for (const { nodeCount, randomEdgeCount } of tests) {
   const viz = await instance();
-  const src = makeGraph(nodeCount, randomEdgeCount);
+  const src = dotStringify(randomGraph(nodeCount, randomEdgeCount));
 
   let callCount = 0;
 

--- a/packages/viz/test/manual/utils.mjs
+++ b/packages/viz/test/manual/utils.mjs
@@ -1,18 +1,38 @@
-export function makeGraph(nodeCount, randomEdgeCount = 0) {
-  let src = "digraph { ";
+export function randomGraph(nodeCount, randomEdgeCount = 0) {
+  const result = {
+    nodes: [],
+    edges: []
+  };
 
   for (let i = 0; i < nodeCount; i++) {
-    src += `node${i}; `;
+    result.nodes.push({ name: `node${i}` });
   }
 
   for (let i = 0; i < randomEdgeCount; i++) {
-    const s = Math.floor(nodeCount * Math.random());
     const t = Math.floor(nodeCount * Math.random());
+    const h = Math.floor(nodeCount * Math.random());
 
-    src += `node${s} -> node${t}; `;
+    result.edges.push({ tail: `node${t}`, head: `node${h}` });
   }
 
-  src += "}";
+  return result;
+}
 
-  return src;
+export function dotStringify(obj) {
+  const edges = Array.from(obj);
+  const result = [];
+
+  result.push("digraph {\n");
+
+  for (const node of obj.nodes) {
+    result.push(node.name, ";\n");
+  }
+
+  for (const edge of obj.edges) {
+    result.push(edge.tail, " -> ", edge.head, ";\n");
+  }
+
+  result.push("}\n");
+
+  return result.join("");
 }

--- a/packages/viz/test/standalone.test.mjs
+++ b/packages/viz/test/standalone.test.mjs
@@ -135,6 +135,37 @@ describe("standalone", function() {
         });
       });
 
+      it("accepts default attributes", function() {
+        const result = viz.render("graph {}", {
+          defaultAttributes: {
+            graph: {
+              a: 123
+            },
+            node: {
+              b: false
+            },
+            edge: {
+              c: "test"
+            }
+          }
+        });
+
+        assert.deepStrictEqual(result, {
+          status: "success",
+          output: `graph {
+	graph [a=123,
+		bb="0,0,0,0"
+	];
+	node [b=false,
+		label="\\N"
+	];
+	edge [c=test];
+}
+`,
+          errors: []
+        });
+      });
+
       it("returns an error for empty input", function() {
         const result = viz.render("");
 
@@ -317,6 +348,37 @@ stop
             output: `digraph {
 	graph [bb="0,0,0,0"];
 	node [label="\\N"];
+}
+`,
+            errors: []
+          });
+        });
+
+        it("default attributes render options override options in input", function() {
+          const result = viz.render(
+            {
+              defaultAttributes: {
+                node: {
+                  shape: "rectangle"
+                }
+              }
+            },
+            {
+              defaultAttributes: {
+                node: {
+                  shape: "circle"
+                }
+              }
+            }
+          );
+
+          assert.deepStrictEqual(result, {
+            status: "success",
+            output: `digraph {
+	graph [bb="0,0,0,0"];
+	node [label="\\N",
+		shape=circle
+	];
 }
 `,
             errors: []

--- a/packages/viz/test/types/index.ts
+++ b/packages/viz/test/types/index.ts
@@ -24,6 +24,11 @@ instance().then(viz => {
   options.format = "dot";
   options.engine = "dot";
   options.yInvert = true;
+  options.defaultAttributes = {
+    graph: { rankdir: "LR" },
+    node: { width: 2 },
+    edge: { color: "green" }
+  };
 
   // @ts-expect-error
   options.format = false;
@@ -42,6 +47,7 @@ instance().then(viz => {
   result = viz.render("digraph { a -> b }");
   result = viz.render("digraph { a -> b }", { format: "svg" });
   result = viz.render("digraph { a -> b }", { format: "svg", engine: "dot", yInvert: false });
+  result = viz.render("digraph { a -> b }", { defaultAttributes: { node: { shape: "circle" } } });
   result = viz.render({});
   result = viz.render({
     edges: [

--- a/packages/viz/test/types/index.ts
+++ b/packages/viz/test/types/index.ts
@@ -42,6 +42,54 @@ instance().then(viz => {
   result = viz.render("digraph { a -> b }");
   result = viz.render("digraph { a -> b }", { format: "svg" });
   result = viz.render("digraph { a -> b }", { format: "svg", engine: "dot", yInvert: false });
+  result = viz.render({});
+  result = viz.render({
+    edges: [
+      { tail: "a", head: "b" }
+    ]
+  });
+  result = viz.render({
+    directed: false,
+    strict: false,
+    name: "G",
+    defaultAttributes: {
+      node: {
+        shape: "circle"
+      }
+    },
+    attributes: {
+      label: "Test"
+    },
+    nodes: [
+      { name: "a", attributes: { label: "A" } }
+    ],
+    edges: [
+      { tail: "a", head: "b" }
+    ],
+    subgraphs: [
+      {
+        name: "cluster1",
+        defaultAttributes: {
+          edge: {
+            color: "blue"
+          }
+        },
+        attributes: {
+          color: "green"
+        },
+        subgraphs: [
+          {
+            nodes: [
+              { name: "b" }
+            ]
+          }
+        ]
+      }
+    ]
+  });
+
+  // @ts-expect-error
+  result = viz.render({ a: "b" });
 
   switch (result.status) {
   case "success":

--- a/packages/viz/test/types/package.json
+++ b/packages/viz/test/types/package.json
@@ -5,6 +5,6 @@
     "typescript": "^5.1.3"
   },
   "scripts": {
-    "check-types": "tsc --strict --noEmit index.ts"
+    "check-types": "tsc --strict --lib es2015,dom --noEmit index.ts"
   }
 }

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -37,6 +37,7 @@ export type RenderOptions = {
   format?: string;
   engine?: string;
   yInvert?: boolean;
+  defaultAttributes?: DefaultAttributes
 };
 
 export type RenderError = {

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -1,3 +1,38 @@
+type DefaultAttributes = {
+  graph?: object,
+  node?: object,
+  edge?: object
+};
+
+type Node = {
+  name: string,
+  attributes?: object
+};
+
+type Edge = {
+  tail: string,
+  head: string,
+  attributes?: object
+};
+
+type Graph = {
+  name?: string,
+  defaultAttributes?: DefaultAttributes,
+  attributes?: object,
+  nodes?: Node[],
+  edges?: Edge[],
+  subgraphs?: Graph[]
+};
+
+type Header = {
+  strict?: boolean,
+  directed?: boolean
+};
+
+export type RenderInputObject = Header & Graph;
+
+type RenderInput = string | RenderInputObject;
+
 export type RenderOptions = {
   format?: string;
   engine?: string;
@@ -28,10 +63,10 @@ declare class Viz {
   get formats(): string[];
   get engines(): string[];
 
-  render(src: string, options?: RenderOptions): RenderResult;
-  renderString(src: string, options?: RenderOptions): string;
-  renderSVGElement(src: string, options?: RenderOptions): SVGSVGElement;
-  renderJSON(src: string, options?: RenderOptions): object;
+  render(input: RenderInput, options?: RenderOptions): RenderResult;
+  renderString(input: RenderInput, options?: RenderOptions): string;
+  renderSVGElement(input: RenderInput, options?: RenderOptions): SVGSVGElement;
+  renderJSON(input: RenderInput, options?: RenderOptions): object;
 }
 export {};
 


### PR DESCRIPTION
Render functions can now accept an object as input, as well as a string in DOT syntax. This makes it easier to render graphs based on model objects in your program, because you can map them to JavaScript objects rather than assembling a string and worrying about quoting, etc.

This also addresses the feature request in #104 by adding an option for default attributes that applies to both string and object input.