### PR TITLE
Added image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ Viz.instance().then(function(viz) {
     a -> b
 
     a [label=<<table>
-      <tr><td>Image:</td></tr>
-      <tr><td><img src="https://picsum.photos/id/184/100/100"/></td></tr>
+      <tr><td>Image inside table:</td></tr>
+      <tr><td><img src="https://picsum.photos/id/184/200/200"/></td></tr>
     </table>>]
 
     b [image="https://picsum.photos/id/250/200/100"]
 
   }`, {images: [
-    {path: 'https://picsum.photos/id/184/100/100', width: 100, height: 100},
+    {path: 'https://picsum.photos/id/184/200/200', width: 200, height: 200},
     {path: 'https://picsum.photos/id/250/200/100', width: 200, height: 100},
   ]}));
-})
+});
 ```
 
 Other packages:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ instance().then(viz => {
 });
 ```
 
+You may add images as well:
+```js
+Viz.instance().then(function(viz) {
+  document.body.appendChild(viz.renderSVGElement(`digraph {
+
+    a -> b
+
+    a [label=<<table>
+      <tr><td>Image:</td></tr>
+      <tr><td><img src="https://picsum.photos/id/184/100/100"/></td></tr>
+    </table>>]
+
+    b [image="https://picsum.photos/id/250/200/100"]
+
+  }`, {images: [
+    {path: 'https://picsum.photos/id/184/100/100', width: 100, height: 100},
+    {path: 'https://picsum.photos/id/250/200/100', width: 200, height: 100},
+  ]}));
+})
+```
+
 Other packages:
 
 - [lang-dot](./packages/lang-dot) — CodeMirror language support for the Graphviz DOT language.

--- a/packages/examples/images/index.html
+++ b/packages/examples/images/index.html
@@ -4,20 +4,20 @@
 <script src="./node_modules/@viz-js/viz/lib/viz-standalone.js"></script>
 <script>
 
-  Viz.instance().then(function(viz) {
+Viz.instance().then(function(viz) {
     document.body.appendChild(viz.renderSVGElement(`digraph {
 
       a -> b
 
       a [label=<<table>
-        <tr><td>Image:</td></tr>
-        <tr><td><img src="https://picsum.photos/id/238/100/100"/></td></tr>
+        <tr><td>Image inside table:</td></tr>
+        <tr><td><img src="https://picsum.photos/id/184/200/200"/></td></tr>
       </table>>]
 
       b [image="https://picsum.photos/id/250/200/100"]
 
     }`, {images: [
-      {path: 'https://picsum.photos/id/238/100/100', width: 100, height: 100},
+      {path: 'https://picsum.photos/id/184/200/200', width: 200, height: 200},
       {path: 'https://picsum.photos/id/250/200/100', width: 200, height: 100},
     ]}));
   });

--- a/packages/examples/images/index.html
+++ b/packages/examples/images/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf8">
+
+<script src="./node_modules/@viz-js/viz/lib/viz-standalone.js"></script>
+<script>
+
+  Viz.instance().then(function(viz) {
+    document.body.appendChild(viz.renderSVGElement(`digraph {
+
+      a -> b
+
+      a [label=<<table>
+        <tr><td>Image:</td></tr>
+        <tr><td><img src="https://picsum.photos/id/238/100/100"/></td></tr>
+      </table>>]
+
+      b [image="https://picsum.photos/id/250/200/100"]
+
+    }`, {images: [
+      {path: 'https://picsum.photos/id/238/100/100', width: 100, height: 100},
+      {path: 'https://picsum.photos/id/250/200/100', width: 200, height: 100},
+    ]}));
+  });
+
+</script>

--- a/packages/examples/images/package.json
+++ b/packages/examples/images/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@viz-js/images-example",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@viz-js/viz": "3.1.0"
+  }
+}

--- a/packages/viz/src/module/Dockerfile
+++ b/packages/viz/src/module/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=graphviz "${PREFIX}" "${PREFIX}"
 COPY viz.c pre.js .
 
 RUN mkdir -p "${OUTPUT}"
-RUN emcc -Oz ${DEBUG:+-g2} --closure=0 --no-entry -sMODULARIZE=1 -sMINIMAL_RUNTIME=1 -sFILESYSTEM=0 -sASSERTIONS=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web -sEXPORT_KEEPALIVE=1 -sEXPORTED_FUNCTIONS="['_malloc', '_free']" -s EXPORTED_RUNTIME_METHODS="['ccall', 'UTF8ToString', 'lengthBytesUTF8', 'stringToUTF8', 'getValue']" -sINCOMING_MODULE_JS_API="['wasm']" --pre-js pre.js -o "${OUTPUT}/module.mjs" viz.c -I"${PREFIX}/include" -I"${PREFIX}/include/graphviz" -L"${PREFIX}/lib" -L"${PREFIX}/lib/graphviz" -lgvplugin_dot_layout -lgvplugin_neato_layout -lgvplugin_core -lgvc -lpathplan -lcgraph -lxdot -lcdt -lexpat
+RUN emcc -Oz ${DEBUG:+-g2} --closure=0 --no-entry -sMODULARIZE=1 -sMINIMAL_RUNTIME=1 -sFORCE_FILESYSTEM -sASSERTIONS=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web -sEXPORT_KEEPALIVE=1 -sEXPORTED_FUNCTIONS="['_malloc', '_free']" -s EXPORTED_RUNTIME_METHODS="['ccall', 'UTF8ToString', 'lengthBytesUTF8', 'stringToUTF8', 'getValue', 'FS', 'PATH']" -sINCOMING_MODULE_JS_API="['wasm']" --pre-js pre.js -o "${OUTPUT}/module.mjs" viz.c -I"${PREFIX}/include" -I"${PREFIX}/include/graphviz" -L"${PREFIX}/lib" -L"${PREFIX}/lib/graphviz" -lgvplugin_dot_layout -lgvplugin_neato_layout -lgvplugin_core -lgvc -lpathplan -lcgraph -lxdot -lcdt -lexpat
 
 
 FROM scratch AS export

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -39,12 +39,25 @@ export type RenderInputObject = Header & Graph;
 
 type RenderInput = string | RenderInputObject;
 
+export type File = {
+  path: string;
+  data: string;
+}
+
+export type ImageFile = {
+  path: string;
+  width: number;
+  height: number;
+}
+
 export type RenderOptions = {
   format?: string;
   engine?: string;
   yInvert?: boolean;
   reduce?: boolean;
-  defaultAttributes?: DefaultAttributes
+  files?: File[];
+  images?: ImageFile[];
+  defaultAttributes?: DefaultAttributes;
 };
 
 export type RenderError = {


### PR DESCRIPTION
With these changes, you may include images or other files inside a graph.

This should solve  #191 

```js
Viz.instance().then(function(viz) {
  document.body.appendChild(viz.renderSVGElement(`digraph {

    a -> b

    a [label=<<table>
      <tr><td>Image:</td></tr>
      <tr><td><img src="https://picsum.photos/id/184/100/100"/></td></tr>
    </table>>]

    b [image="https://picsum.photos/id/250/200/100"]

  }`, {images: [
    {path: 'https://picsum.photos/id/184/100/100', width: 100, height: 100},
    {path: 'https://picsum.photos/id/250/200/100', width: 200, height: 100},
  ]}));
})
```
