### PR TITLE
Remove release job from publish workflows

### DIFF
--- a/.github/workflows/lang-dot-publish.yml
+++ b/.github/workflows/lang-dot-publish.yml
@@ -8,24 +8,6 @@ jobs:
   build:
     uses: ./.github/workflows/lang-dot-build.yml
 
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: packages/lang-dot/dist
-
-      - run: gh release create "${{ github.ref }}" --draft --title "${{ github.ref_name }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
-        working-directory: packages/lang-dot
-
   publish:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/viz-publish.yml
+++ b/.github/workflows/viz-publish.yml
@@ -8,24 +8,6 @@ jobs:
   build:
     uses: ./.github/workflows/viz-build.yml
 
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: lib
-          path: packages/viz/lib
-
-      - run: gh release create "${{ github.ref }}" --draft --title "${{ github.ref_name }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
-        working-directory: packages/viz
-
   publish:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Instead, I'll create a GitHub release manually, and the publish job will be trigged when a tag is created.