### PR TITLE
Add a workaround for node names not being used as labels

### DIFF
--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add a workaround for node names not being used as labels (#218)
+
 ## 3.2.2
 
 * Include types condition in exports

--- a/packages/viz/src/module/viz.c
+++ b/packages/viz/src/module/viz.c
@@ -73,6 +73,10 @@ Agraph_t *viz_read_one_graph(char *string) {
   Agraph_t *graph = NULL;
   Agraph_t *other_graph = NULL;
 
+  // Workaround for #218. Set the global default node label.
+
+  agattr(NULL, AGNODE, "label", "\\N");
+
   // Reset errors
 
   agseterrf(viz_errorf);

--- a/packages/viz/test/render.test.mjs
+++ b/packages/viz/test/render.test.mjs
@@ -290,7 +290,7 @@ stop
         status: "success",
         output: "graph {\n\tgraph [_background=123,\n\t\tbb=\"0,0,0,0\"\n\t];\n\tnode [label=\"\\N\"];\n}\n",
         errors: [
-          { level: "warning", message: "Could not parse \"_background\" attribute in graph %1" },
+          { level: "warning", message: "Could not parse \"_background\" attribute in graph %3" },
           { level: "warning", message: "  \"123\"" }
         ]
       });
@@ -306,6 +306,27 @@ stop
           { level: "error", message: "syntax error in line 1" },
           { level: "error", message: "... <HTML></HTML> ..." }
         ]
+      });
+    });
+
+    it("the graph is read with the default node label set", function() {
+      const result = viz.render("graph { a; b[label=test] }");
+
+      assert.deepStrictEqual(result, {
+        status: "success",
+        output: `graph {
+	graph [bb="0,0,126,36"];
+	node [label="\\N"];
+	a	[height=0.5,
+		pos="27,18",
+		width=0.75];
+	b	[height=0.5,
+		label=test,
+		pos="99,18",
+		width=0.75];
+}
+`,
+        errors: []
       });
     });
   });


### PR DESCRIPTION
This adds a workaround for issue #218.

When rendering from a string, Viz.js reads the string before it creates a Graphviz context. It then creates a context which it uses for layout and rendering.

However, this can sometimes cause labels to not be displayed, but only for the first call to `render()`. Creating a Graphviz context initializes the global default node `label` attribute to be `\N`, which is replaced with the node's name if no label is set on a node. So if we don't create a context before reading the first graph, we don't set the default label. The result is that for the first graph we render, nodes without labels set explicitly won't have their name used for their label.

The usual sequence seems to be: create a context first, then read the graph and do layout and rendering, then free the context.

The workaround in this PR sets the default label for nodes before reading a graph, as would be done when creating a context. It might be preferable to simply create a context before reading the graph and use it for layout and rendering, but that would require a larger change.