### PR TITLE
Export the Viz type

### DIFF
--- a/.github/workflows/viz-build.yml
+++ b/.github/workflows/viz-build.yml
@@ -115,5 +115,4 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn check-types
-          yarn check-types-esnext
         working-directory: packages/viz/test/types

--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Export the Viz type (#224, #225)
+
 ## 3.2.3
 
 * Add a workaround for node names not being used as labels (#218)

--- a/packages/viz/test/types/not-exported.ts
+++ b/packages/viz/test/types/not-exported.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error
+import { Viz } from "@viz-js/viz";
+
+// @ts-expect-error
+import { type SuccessResult } from "@viz-js/viz";
+
+// @ts-expect-error
+import { type FailureResult } from "@viz-js/viz";

--- a/packages/viz/test/types/package.json
+++ b/packages/viz/test/types/package.json
@@ -1,11 +1,11 @@
 {
   "private": true,
+  "type": "module",
   "dependencies": {
     "@viz-js/viz": "link:../..",
     "typescript": "^5.1.3"
   },
   "scripts": {
-    "check-types": "tsc --strict --lib es2015,dom --noEmit *.ts",
-    "check-types-esnext": "tsc --strict --lib es2015,dom --module esnext --moduleResolution bundler --noEmit *.ts"
+    "check-types": "tsc --strict --lib es2015,dom --module esnext --moduleResolution bundler --verbatimModuleSyntax --noEmit *.ts"
   }
 }

--- a/packages/viz/test/types/top-level.ts
+++ b/packages/viz/test/types/top-level.ts
@@ -1,16 +1,4 @@
-import { instance, graphvizVersion, formats, engines, type RenderOptions, type RenderResult, type RenderError } from "@viz-js/viz";
-
-// @ts-expect-error
-import { Viz } from "@viz-js/viz";
-
-// @ts-expect-error
-import { type Viz } from "@viz-js/viz";
-
-// @ts-expect-error
-import { type SuccessResult } from "@viz-js/viz";
-
-// @ts-expect-error
-import { type FailureResult } from "@viz-js/viz";
+import { instance, graphvizVersion, formats, engines, type RenderOptions, type RenderResult, type RenderError, type Viz } from "@viz-js/viz";
 
 let version: string = graphvizVersion;
 

--- a/packages/viz/test/types/viz.ts
+++ b/packages/viz/test/types/viz.ts
@@ -1,4 +1,8 @@
-import { instance } from "@viz-js/viz";
+import { instance, type Viz } from "@viz-js/viz";
+
+export function myRender(viz: Viz, src: string): string {
+  return viz.renderString(src, { graphAttributes: { label: "My graph" } });
+}
 
 instance().then(viz => {
   viz.render("digraph { a -> b }");
@@ -10,6 +14,8 @@ instance().then(viz => {
   viz.render("digraph { a -> b }", { nodeAttributes: { shape: "circle" } });
 
   viz.render({ edges: [{ tail: "a", head: "b" }] });
+
+  myRender(viz, "digraph { a -> b }");
 
   // @ts-expect-error
   viz.render("digraph { a -> b }", { format: false });

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -18,6 +18,8 @@ declare class Viz {
   renderJSON(input: string | Graph, options?: RenderOptions): object
 }
 
+export { type Viz }
+
 export interface RenderOptions {
   format?: string
   engine?: string


### PR DESCRIPTION
This adds an export for the `Viz` type to the declaration file for the `viz` package. The class itself isn't exported in JavaScript, but TypeScript users may want to refer to the type when dealing with instances of the class.

For example, a wrapper function that accepts an instance of `Viz`:

```ts
import { type Viz } from "@viz-js/viz";

export function myRender(viz: Viz, src: string): string {
  return viz.renderString(src, { graphAttributes: { label: "My graph" } });
}
```