### PR TITLE
Update Graphviz to 10.0.1

### DIFF
--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Update Graphviz to 10.0.1.
+
 ## 3.3.1
 
 * Accept "images" entries with duplicate names.

--- a/packages/viz/src/module/Dockerfile
+++ b/packages/viz/src/module/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p expat && tar -zxf ./expat.tar.gz --strip-components 1 --directory e
 RUN cd expat && emconfigure ./configure --host=wasm32 --disable-shared --prefix="${PREFIX}" --libdir="${PREFIX}/lib" CFLAGS="-Oz" CXXFLAGS="-Oz"
 RUN cd expat/lib && emmake make all install
 
-ADD "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/9.0.0/graphviz-9.0.0.tar.gz" ./graphviz.tar.gz
+ADD "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/10.0.1/graphviz-10.0.1.tar.gz" ./graphviz.tar.gz
 
 RUN mkdir -p graphviz && tar -zxf ./graphviz.tar.gz --strip-components 1 --directory graphviz
 RUN cd graphviz && emconfigure ./configure --host=wasm32 --disable-ltdl --prefix="${PREFIX}" --libdir="${PREFIX}/lib" EXPAT_CFLAGS="-I${PREFIX}/include" EXPAT_LIBS="-L${PREFIX}/lib -lexpat" CFLAGS="-Oz" CXXFLAGS="-Oz"

--- a/packages/viz/src/module/viz.c
+++ b/packages/viz/src/module/viz.c
@@ -1,5 +1,6 @@
 #include <gvc.h>
 #include <emscripten.h>
+#include <stdbool.h>
 
 extern int Y_invert;
 extern unsigned char Reduce;
@@ -116,19 +117,19 @@ int viz_string_free(Agraph_t * g, const char *s) {
 
 EMSCRIPTEN_KEEPALIVE
 Agnode_t *viz_add_node(Agraph_t *g, char *name) {
-  return agnode(g, name, TRUE);
+  return agnode(g, name, true);
 }
 
 EMSCRIPTEN_KEEPALIVE
 Agedge_t *viz_add_edge(Agraph_t *g, char *uname, char *vname) {
-  Agnode_t *u = agnode(g, uname, TRUE);
-  Agnode_t *v = agnode(g, vname, TRUE);
-  return agedge(g, u, v, NULL, TRUE);
+  Agnode_t *u = agnode(g, uname, true);
+  Agnode_t *v = agnode(g, vname, true);
+  return agedge(g, u, v, NULL, true);
 }
 
 EMSCRIPTEN_KEEPALIVE
 Agraph_t *viz_add_subgraph(Agraph_t *g, char *name) {
-  return agsubg(g, name, TRUE);
+  return agsubg(g, name, true);
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/packages/viz/test/context-info.test.mjs
+++ b/packages/viz/test/context-info.test.mjs
@@ -10,7 +10,7 @@ describe("Viz", function() {
 
   describe("graphvizVersion", function() {
     it("returns the Graphviz version", function() {
-      assert.strictEqual(viz.graphvizVersion, "9.0.0");
+      assert.strictEqual(viz.graphvizVersion, "10.0.1");
     });
   });
 
@@ -39,6 +39,7 @@ describe("Viz", function() {
         "ps",
         "ps2",
         "svg",
+        "svg_inline",
         "tk",
         "xdot",
         "xdot1.2",

--- a/packages/viz/test/render.test.mjs
+++ b/packages/viz/test/render.test.mjs
@@ -266,7 +266,7 @@ stop
         status: "failure",
         output: undefined,
         errors: [
-          { level: "error", message: "Format: \"invalid\" not recognized. Use one of: canon cmap cmapx cmapx_np dot dot_json eps fig gv imap imap_np ismap json json0 mp pic plain plain-ext pov ps ps2 svg tk xdot xdot1.2 xdot1.4 xdot_json" }
+          { level: "error", message: "Format: \"invalid\" not recognized. Use one of: canon cmap cmapx cmapx_np dot dot_json eps fig gv imap imap_np ismap json json0 mp pic plain plain-ext pov ps ps2 svg svg_inline tk xdot xdot1.2 xdot1.4 xdot_json" }
         ]
       });
     });
@@ -292,19 +292,6 @@ stop
         errors: [
           { level: "warning", message: "Could not parse \"_background\" attribute in graph %3" },
           { level: "warning", message: "  \"123\"" }
-        ]
-      });
-    });
-
-    it("returns an error if exit() is called", function() {
-      const result = viz.render("graph { a[label=<>] }");
-
-      assert.deepStrictEqual(result,{
-        status: "failure",
-        output: undefined,
-        errors: [
-          { level: "error", message: "syntax error in line 1" },
-          { level: "error", message: "... <HTML></HTML> ..." }
         ]
       });
     });

--- a/packages/viz/test/standalone.test.mjs
+++ b/packages/viz/test/standalone.test.mjs
@@ -4,7 +4,7 @@ import Viz from "../src/viz.mjs";
 
 describe("graphvizVersion", function() {
   it("returns the Graphviz version", function() {
-    assert.strictEqual(VizPackage.graphvizVersion, "9.0.0");
+    assert.strictEqual(VizPackage.graphvizVersion, "10.0.1");
   });
 });
 
@@ -33,6 +33,7 @@ describe("formats", function() {
       "ps",
       "ps2",
       "svg",
+      "svg_inline",
       "tk",
       "xdot",
       "xdot1.2",


### PR DESCRIPTION
- Fix usage of TRUE and FALSE
- Remove test that depended on Graphviz exiting for invalid HTML labels
- Add svg_inline to tests that check the list of formats