### PR TITLE
Add a method to render multiple output formats

### DIFF
--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* Add renderFormats() method.
+
+  This method accepts an array of formats to render. Using this method avoids redundant parsing and layout when rendering the same graph in multiple formats, similar to specifying multiple formats when using the Graphviz command-line.
+  
+  The return value is similar to the render() method, but the "output" value is an object keyed by format.
+  
+     const result = viz.renderFormats("digraph { a -> b [href=\"https://example.com\"] }", ["svg", "cmapx"], { engine: "neato" });
+     result.output // => { "svg": ..., "cmapx": ... }
+
 ## 3.9.0
 
 * Update Graphviz to 12.1.1.

--- a/packages/viz/src/viz.mjs
+++ b/packages/viz/src/viz.mjs
@@ -17,8 +17,26 @@ class Viz {
     return this.wrapper.getPluginList("layout");
   }
 
+  renderFormats(input, formats, options = {}) {
+    return this.wrapper.renderInput(input, formats, { engine: "dot", ...options });
+  }
+
   render(input, options = {}) {
-    return this.wrapper.renderInput(input, { format: "dot", engine: "dot", ...options });
+    let format;
+
+    if (options.format === void 0) {
+      format = "dot";
+    } else {
+      format = options.format;
+    }
+
+    let result = this.wrapper.renderInput(input, [format], { engine: "dot", ...options });
+
+    if (result.status === "success") {
+      result.output = result.output[format];
+    }
+
+    return result;
   }
 
   renderString(src, options = {}) {

--- a/packages/viz/test/manual/instance-reuse.mjs
+++ b/packages/viz/test/manual/instance-reuse.mjs
@@ -31,6 +31,7 @@ const tests = [
   { label: "string", fn: viz => viz.render(dotStringify(makeObject())) },
   { label: "string with labels", fn: viz => viz.render(dotStringify(makeObjectWithLabels())) },
   { label: "string with HTML labels", fn: viz => viz.render(dotStringify(makeObjectWithHTMLLabels())) },
+  { label: "string with multiple formats", fn: viz => viz.renderFormats(dotStringify(makeObject()), ["svg", "cmapx"]) },
   { label: "object", fn: viz => viz.render(makeObject()) },
   { label: "object with labels", fn: viz => viz.render(makeObjectWithLabels()) },
   { label: "object with HTML labels", fn: viz => viz.render(makeObjectWithHTMLLabels()) },

--- a/packages/viz/test/manual/performance-multiple.mjs
+++ b/packages/viz/test/manual/performance-multiple.mjs
@@ -9,19 +9,24 @@ const tests = [
 ];
 
 tests.forEach(test => {
-  test.input = randomGraph(test.nodeCount, test.randomEdgeCount);
+  test.input = dotStringify(randomGraph(test.nodeCount, test.randomEdgeCount));
 });
 
 const timeLimit = 5000;
 
 for (const { input, nodeCount, randomEdgeCount } of tests) {
   const viz = await instance();
-  const result = measure(() => viz.render(dotStringify(input)), timeLimit);
-  console.log(`stringify, ${nodeCount} nodes, ${randomEdgeCount} edges: ${result}`);
+  const result = measure(() => {
+    viz.render(input, { format: "svg" });
+    viz.render(input, { format: "cmapx" });
+  }, timeLimit);
+  console.log(`render, ${nodeCount} nodes, ${randomEdgeCount} edges: ${result}`);
 }
 
 for (const { input, nodeCount, randomEdgeCount } of tests) {
   const viz = await instance();
-  const result = measure(() => viz.render(input), timeLimit);
-  console.log(`map, ${nodeCount} nodes, ${randomEdgeCount} edges: ${result}`);
+  const result = measure(() => {
+    viz.renderFormats(input, ["svg", "cmapx"]);
+  }, timeLimit);
+  console.log(`renderFormats, ${nodeCount} nodes, ${randomEdgeCount} edges: ${result}`);
 }

--- a/packages/viz/test/manual/performance-timing.mjs
+++ b/packages/viz/test/manual/performance-timing.mjs
@@ -1,5 +1,5 @@
 import { instance } from "../../src/standalone.mjs";
-import { randomGraph, dotStringify } from "./utils.mjs";
+import { measure, randomGraph, dotStringify } from "./utils.mjs";
 
 const tests = [
   { nodeCount: 100, randomEdgeCount: 0 },
@@ -13,24 +13,14 @@ const tests = [
   { nodeCount: 100, randomEdgeCount: 300 }
 ];
 
+tests.forEach(test => {
+  test.input = dotStringify(randomGraph(test.nodeCount, test.randomEdgeCount));
+});
+
 const timeLimit = 5000;
 
-for (const { nodeCount, randomEdgeCount } of tests) {
+for (const { input, nodeCount, randomEdgeCount } of tests) {
   const viz = await instance();
-  const src = dotStringify(randomGraph(nodeCount, randomEdgeCount));
-
-  let callCount = 0;
-
-  const startTime = performance.now();
-
-  while (performance.now() - startTime < timeLimit) {
-    viz.render(src);
-    callCount++;
-  }
-
-  const stopTime = performance.now();
-  const duration = (stopTime - startTime) / 1000;
-  const speed = callCount / duration;
-
-  console.log(`${nodeCount} nodes, ${randomEdgeCount} edges: ${callCount} in ${duration.toFixed(2)} s, ${speed.toFixed(2)} calls/s`);
+  const result = measure(() => viz.render(input), timeLimit);
+  console.log(`${nodeCount} nodes, ${randomEdgeCount} edges: ${result}`);
 }

--- a/packages/viz/test/manual/utils.mjs
+++ b/packages/viz/test/manual/utils.mjs
@@ -1,3 +1,20 @@
+export function measure(operation, timeLimit) {
+  let callCount = 0;
+
+  const startTime = performance.now();
+
+  while (performance.now() - startTime < timeLimit) {
+    operation();
+    callCount++;
+  }
+
+  const stopTime = performance.now();
+  const duration = (stopTime - startTime) / 1000;
+  const speed = callCount / duration;
+
+  return `${callCount} in ${duration.toFixed(2)} s, ${speed.toFixed(2)} calls/s`
+}
+
 const skipQuotePattern = /^([A-Za-z_][A-Za-z_0-9]*|-?(\.[0-9]+|[0-9]+(\.[0-9]+)?))$/;
 
 function quote(value) {

--- a/packages/viz/test/render-formats.test.mjs
+++ b/packages/viz/test/render-formats.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import * as VizPackage from "../src/standalone.mjs";
+
+describe("Viz", function() {
+  let viz;
+
+  beforeEach(async function() {
+    viz = await VizPackage.instance();
+  });
+
+  describe("renderFormats", function() {
+    it("renders multiple output formats", function() {
+      const result = viz.renderFormats("graph a { }", ["dot", "cmapx"]);
+
+      assert.deepStrictEqual(result, {
+        status: "success",
+        output: {
+          dot: "graph a {\n\tgraph [bb=\"0,0,0,0\"];\n\tnode [label=\"\\N\"];\n}\n",
+          cmapx: "<map id=\"a\" name=\"a\">\n</map>\n"
+        },
+        errors: []
+      });
+    });
+
+    it("renders with the same format twice", function() {
+      const result = viz.renderFormats("graph a { }", ["dot", "dot"]);
+
+      assert.deepStrictEqual(result, {
+        status: "success",
+        output: {
+          dot: "graph a {\n\tgraph [bb=\"0,0,0,0\"];\n\tnode [label=\"\\N\"];\n}\n"
+        },
+        errors: []
+      });
+    });
+
+    it("renders with an empty array of formats", function() {
+      const result = viz.renderFormats("graph a { }", []);
+
+      assert.deepStrictEqual(result, {
+        status: "success",
+        output: {},
+        errors: []
+      });
+    });
+
+    it("accepts options", function() {
+      const result = viz.renderFormats("graph a { b }", ["dot", "cmapx"], { engine: "neato", reduce: true });
+
+      assert.deepStrictEqual(result, {
+        status: "success",
+        output: {
+          dot: "graph a {\n\tgraph [bb=\"0,0,0,0\"];\n\tnode [label=\"\\N\"];\n}\n",
+          cmapx: "<map id=\"a\" name=\"a\">\n</map>\n"
+        },
+        errors: []
+      });
+    });
+
+    it("returns error messages for invalid input", function() {
+      const result = viz.renderFormats("invalid", ["dot", "cmapx"]);
+
+      assert.deepStrictEqual(result, {
+        status: "failure",
+        output: undefined,
+        errors: [
+          { level: "error", message: "syntax error in line 1 near 'invalid'" }
+        ]
+      });
+    });
+
+    it("returns error messages for invalid input and an empty array of formats", function() {
+      const result = viz.renderFormats("invalid", []);
+
+      assert.deepStrictEqual(result, {
+        status: "failure",
+        output: undefined,
+        errors: [
+          { level: "error", message: "syntax error in line 1 near 'invalid'" }
+        ]
+      });
+    });
+  });
+});

--- a/packages/viz/test/types/render-formats.ts
+++ b/packages/viz/test/types/render-formats.ts
@@ -1,0 +1,45 @@
+import { instance, type MultipleRenderResult, type RenderError } from "@viz-js/viz";
+
+instance().then(viz => {
+  let result: MultipleRenderResult = viz.renderFormats("digraph { a -> b }", ["svg", "cmapx"]);
+
+  switch (result.status) {
+  case "success":
+    {
+      let output: string = result.output["svg"];
+      break;
+    }
+
+  case "failure":
+    {
+      // @ts-expect-error
+      let output: string = result.output;
+      break;
+    }
+
+  // @ts-expect-error
+  case "invalid":
+    break;
+  }
+
+  let error: RenderError | undefined = result.errors[0];
+
+  if (typeof error !== "undefined") {
+    let message: string = error.message;
+
+    switch (error.level) {
+    case "error":
+      break;
+
+    case "warning":
+      break;
+
+    case undefined:
+      break;
+
+    // @ts-expect-error
+    case "invalid":
+      break;
+    }
+  }
+});

--- a/packages/viz/test/types/viz.ts
+++ b/packages/viz/test/types/viz.ts
@@ -1,4 +1,4 @@
-import { instance, type Viz } from "@viz-js/viz";
+import { instance, type Viz, type RenderResult, type MultipleRenderResult } from "@viz-js/viz";
 
 export function myRender(viz: Viz, src: string): string {
   return viz.renderString(src, { graphAttributes: { label: "My graph" } });
@@ -10,6 +10,10 @@ instance().then(viz => {
   viz.render("digraph { a -> b }", { format: "svg" });
 
   viz.render("digraph { a -> b }", { format: "svg", engine: "dot", yInvert: false });
+
+  viz.renderFormats("digraph { a -> b }", ["svg", "cmapx"]);
+
+  viz.renderFormats("digraph { a -> b }", ["svg", "cmapx"], { engine: "dot" });
 
   viz.render("digraph { a -> b }", { nodeAttributes: { shape: "circle" } });
 
@@ -28,6 +32,13 @@ instance().then(viz => {
 
   // @ts-expect-error
   viz.render("digraph { a -> b }", { whatever: 123 });
+
+  // @ts-expect-error
+  viz.render("digraph { a -> b }", { format: ["svg"] });
+
+  let result: RenderResult = viz.render("digraph { a -> b }");
+
+  let formatsResult: MultipleRenderResult = viz.renderFormats("digraph { a -> b }", ["svg", "cmapx"]);
 
   let stringResult: string = viz.renderString("digraph { a -> b }");
 

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -13,6 +13,7 @@ declare class Viz {
   get formats(): string[]
   get engines(): string[]
   render(input: string | Graph, options?: RenderOptions): RenderResult
+  renderFormats(input: string | Graph, formats: string[], options?: RenderOptions): MultipleRenderResult
   renderString(input: string | Graph, options?: RenderOptions): string
   renderSVGElement(input: string | Graph, options?: RenderOptions): SVGSVGElement
   renderJSON(input: string | Graph, options?: RenderOptions): object
@@ -42,6 +43,14 @@ interface SuccessResult {
 interface FailureResult {
   status: "failure"
   output: undefined
+  errors: RenderError[]
+}
+
+export type MultipleRenderResult = MultipleSuccessResult | FailureResult
+
+interface MultipleSuccessResult {
+  status: "success"
+  output: { [format: string]: string }
   errors: RenderError[]
 }
 

--- a/packages/website/src/api/index.html
+++ b/packages/website/src/api/index.html
@@ -126,7 +126,20 @@ instance().then(viz => {
 
             <dt id="viz.Viz.render"><code><b><a href="#viz.Viz.render">render</a></b>(input: string | <a href="#viz.Graph">Graph</a>, options?: <a href="#viz.RenderOptions">RenderOptions</a>) &rarr; <a href="#viz.RenderResult">RenderResult</a></code></dt>
             <dd>
-              <p>Renders the graph described by the input and returns the result as an object. <code>input</code> may be a string in <a href="https://www.graphviz.org/doc/info/lang.html">DOT syntax</a> or a <a href="#viz.Graph">graph object</a>.</p>
+              <p>Renders the graph described by the input and returns the result as an object.</p>
+              
+              <p><code>input</code> may be a string in <a href="https://www.graphviz.org/doc/info/lang.html">DOT syntax</a> or a <a href="#viz.Graph">graph object</a>.</p>
+
+              <p>This method does not throw an error if rendering failed, including for invalid DOT syntax, but it will throw for invalid types in input or unexpected runtime errors.</p>
+            </dd>
+            
+            <dt id="viz.Viz.renderFormats"><code><b><a href="#viz.Viz.renderFormats">renderFormats</a></b>(input: string | <a href="#viz.Graph">Graph</a>, formats: string[], options?: <a href="#viz.RenderOptions">RenderOptions</a>) &rarr; <a href="#viz.MultipleRenderResult">MultipleRenderResult</a></code></dt>
+            <dd>
+              <p>Renders the graph described by the input for each format in <code>formats</code> and returns the result as an object. For a successful result, <code><a href="#viz.MultipleSuccessResult.output">output</a></code> is an object keyed by format.</p>
+              
+              <p><code>input</code> may be a string in <a href="https://www.graphviz.org/doc/info/lang.html">DOT syntax</a> or a <a href="#viz.Graph">graph object</a>.</p>
+              
+              <p>The <code><a href="#viz.RenderOptions.format">format</a></code> option is ignored.</p>
 
               <p>This method does not throw an error if rendering failed, including for invalid DOT syntax, but it will throw for invalid types in input or unexpected runtime errors.</p>
             </dd>
@@ -138,12 +151,12 @@ instance().then(viz => {
 
             <dt id="viz.Viz.renderSVGElement"><code><b><a href="#viz.Viz.renderSVGElement">renderSVGElement</a></b>(input: string | <a href="#viz.Graph">Graph</a>, options?: <a href="#viz.RenderOptions">RenderOptions</a>) &rarr; <a href="https://developer.mozilla.org/en-US/docs/Web/API/SVGSVGElement">SVGSVGElement</a></code></dt>
             <dd>
-              <p>Convenience method that renders the input, parses the output, and returns an SVG element. The <a href="#viz.RenderOptions.format">format</a> option is ignored. Throws an error if rendering failed.</p>
+              <p>Convenience method that renders the input, parses the output, and returns an SVG element. The <code><a href="#viz.RenderOptions.format">format</a></code> option is ignored. Throws an error if rendering failed.</p>
             </dd>
 
             <dt id="viz.Viz.renderJSON"><code><b><a href="#viz.Viz.renderJSON">renderJSON</a></b>(input: string | <a href="#viz.Graph">Graph</a>, options?: <a href="#viz.RenderOptions">RenderOptions</a>) &rarr; object</code></dt>
             <dd>
-              <p>Convenience method that renders the input, parses the output, and returns a JSON object. The <a href="#viz.RenderOptions.format">format</a> option is ignored. Throws an error if rendering failed.</p>
+              <p>Convenience method that renders the input, parses the output, and returns a JSON object. The <code><a href="#viz.RenderOptions.format">format</a></code> option is ignored. Throws an error if rendering failed.</p>
             </dd>
           </dl>
         </dd>
@@ -208,6 +221,11 @@ instance().then(viz => {
         <dd>
           <p>The result object returned by <code><a href="#viz.Viz.render">render</a></code>.</p>
         </dd>
+        
+        <dt id="viz.MultipleRenderResult"><code><b><a href="#viz.MultipleRenderResult">MultipleRenderResult</a></b> = <a href="#viz.MultipleSuccessResult">MultipleSuccessResult</a> | <a href="#viz.FailureResult">FailureResult</a></code></dt>
+        <dd>
+          <p>The result object returned by <code><a href="#viz.Viz.renderFormats">renderFormats</a></code>.</p>
+        </dd>
 
         <dt id="viz.SuccessResult"><code><b><a href="#viz.SuccessResult">SuccessResult</a></b></code></dt>
         <dd>
@@ -225,6 +243,28 @@ instance().then(viz => {
             </dd>
 
             <dt id="viz.SuccessResult.errors"><code><b><a href="#viz.SuccessResult.errors">errors</a></b>: <a href="#viz.RenderError">RenderError</a>[]</code></dt>
+            <dd>
+              <p></p>
+            </dd>
+          </dl>
+        </dd>
+
+        <dt id="viz.MultipleSuccessResult"><code><b><a href="#viz.MultipleSuccessResult">MultipleSuccessResult</a></b></code></dt>
+        <dd>
+          <p>Returned by <code><a href="#viz.Viz.renderFormats">renderFormats</a></code> if rendering was successful. <code><a href="#viz.MultipleSuccessResult.errors">errors</a></code> may contain warning messages even if the graph rendered successfully.</p>
+
+          <dl>
+            <dt id="viz.MultipleSuccessResult.status"><code><b><a href="#viz.MultipleSuccessResult.status">status</a></b>: "success"</code></dt>
+            <dd>
+              <p></p>
+            </dd>
+
+            <dt id="viz.MultipleSuccessResult.output"><code><b><a href="#viz.MultipleSuccessResult.output">output</a></b>: { [format: string]: string }</code></dt>
+            <dd>
+              <p></p>
+            </dd>
+
+            <dt id="viz.MultipleSuccessResult.errors"><code><b><a href="#viz.MultipleSuccessResult.errors">errors</a></b>: <a href="#viz.RenderError">RenderError</a>[]</code></dt>
             <dd>
               <p></p>
             </dd>


### PR DESCRIPTION
See #259

Adds a `renderFormats()` method which accepts an array of output formats to render. This avoids redundant parsing and layout when rendering the same graph with multiple output formats. The use case in the linked issue is rendering an SVG and a corresponding image map.

Usage:

```js
const result = viz.renderFormats("digraph { a -> b [href=\"https://example.com\"] }", ["svg", "cmapx"], { engine: "neato" });
result.output // => { "svg": ..., "cmapx": ... }
```

If rendering is successful, `result.output` is an object containing the output for each format, keyed by format.

Results from a basic performance test. This compares separate calls to `render()` with one call to `renderFormats()`:

```
$ node performance-multiple.mjs 
render, 100 nodes, 10 edges: 1863 in 5.00 s, 372.54 calls/s
render, 1000 nodes, 50 edges: 96 in 5.04 s, 19.05 calls/s
render, 1000 nodes, 500 edges: 60 in 5.01 s, 11.98 calls/s
render, 1000 nodes, 1000 edges: 11 in 5.37 s, 2.05 calls/s
renderFormats, 100 nodes, 10 edges: 2706 in 5.00 s, 541.05 calls/s
renderFormats, 1000 nodes, 50 edges: 162 in 5.02 s, 32.24 calls/s
renderFormats, 1000 nodes, 500 edges: 102 in 5.04 s, 20.25 calls/s
renderFormats, 1000 nodes, 1000 edges: 20 in 5.11 s, 3.91 calls/s
```
