### PR TITLE
Add docs to the type declaration file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1519,6 +1519,20 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.2.tgz",
+      "integrity": "sha512-3jXo5bNjvvimvdbIhKGfFxSnKCX+MA8wzHv55ptzk/cx8wOzT+BRcYgj8aFN3yTiTs+zvQQiaZFr7Jce1ZG3fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.4.2",
+        "@shikijs/langs": "^3.4.2",
+        "@shikijs/themes": "^3.4.2",
+        "@shikijs/types": "^3.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "dev": true,
@@ -2886,6 +2900,55 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.2.tgz",
+      "integrity": "sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.2.tgz",
+      "integrity": "sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.4.2"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.2.tgz",
+      "integrity": "sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.4.2"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.2.tgz",
+      "integrity": "sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.7.42",
       "hasInstallScript": true,
@@ -2974,8 +3037,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4340,6 +4420,16 @@
       "version": "1.2.4",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lmdb": {
       "version": "2.8.5",
       "hasInstallScript": true,
@@ -4413,14 +4503,46 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/map-stream": {
       "version": "0.0.7",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4868,6 +4990,16 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5387,10 +5519,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.5.tgz",
+      "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.2.2",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+      }
+    },
+    "node_modules/typedoc-plugin-mdn-links": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-5.0.2.tgz",
+      "integrity": "sha512-Bd3lsVWPSpDkn6NGZyPHpcK088PUvH4SRq4RD97OjA6l8PQA3yOnJhGACtjmIDdcenRTgWUosH+55ANZhx/wkw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc": "0.27.x || 0.28.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5399,6 +5565,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -5648,6 +5821,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "dev": true,
@@ -5749,7 +5935,9 @@
         "@rollup/plugin-terser": "^0.4.1",
         "jsdom": "^21.1.1",
         "mocha": "^11.1.0",
-        "rollup": "^3.29.5"
+        "rollup": "^3.29.5",
+        "typedoc": "^0.28.5",
+        "typedoc-plugin-mdn-links": "^5.0.2"
       }
     },
     "packages/website": {

--- a/packages/viz/.gitignore
+++ b/packages/viz/.gitignore
@@ -1,2 +1,3 @@
 lib/
 node_modules/
+docs/

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -32,9 +32,12 @@
     "@rollup/plugin-terser": "^0.4.1",
     "jsdom": "^21.1.1",
     "mocha": "^11.1.0",
-    "rollup": "^3.29.5"
+    "rollup": "^3.29.5",
+    "typedoc": "^0.28.5",
+    "typedoc-plugin-mdn-links": "^5.0.2"
   },
   "scripts": {
-    "test": "mocha --include \"test/*.test.mjs\""
+    "test": "mocha --include \"test/*.test.mjs\"",
+    "docs": "typedoc types/index.d.ts"
   }
 }

--- a/packages/viz/site/index.md
+++ b/packages/viz/site/index.md
@@ -1,0 +1,36 @@
+Viz.js is a WebAssembly build of Graphviz with a simple JavaScript wrapper.
+
+## Usage
+
+### ES module
+
+<p>The Viz.js ES module is published as a single file, including its WebAssembly code. It exports a function, {@link instance}, which encapsulates decoding the WebAssembly code and instantiating the WebAssembly and Emscripten modules. This returns a promise that resolves to an instance of the {@link Viz} class, which provides methods for {@link Viz.render | rendering graphs}.</p>
+
+```js
+import { instance } from "@viz-js/viz";
+
+instance().then(viz => {
+  const svg = viz.renderSVGElement("digraph { a -> b }");
+
+  document.getElementById("graph").appendChild(svg);
+});
+```
+
+The instance can be used to render multiple graphs.</p>
+
+### UMD Bundle
+
+The package also includes a UMD bundle, <code>lib/viz-standalone.js</code>. This assigns the {@link instance} function to a global <code>Viz</code> object.
+
+```html
+<div id="graph"></div>
+
+<script src="viz-standalone.js"></script>
+<script>
+  Viz.instance().then(function(viz) {
+    var svg = viz.renderSVGElement("digraph { a -> b }");
+
+    document.getElementById("graph").appendChild(svg);
+  });
+</script>
+```

--- a/packages/viz/test/types/not-exported.ts
+++ b/packages/viz/test/types/not-exported.ts
@@ -1,8 +1,0 @@
-// @ts-expect-error
-import { Viz } from "@viz-js/viz";
-
-// @ts-expect-error
-import { type SuccessResult } from "@viz-js/viz";
-
-// @ts-expect-error
-import { type FailureResult } from "@viz-js/viz";

--- a/packages/viz/typedoc.json
+++ b/packages/viz/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "excludeInternal": true,
+  "plugin": [
+    "typedoc-plugin-mdn-links"
+  ],
+  "sort": ["kind", "source-order"],
+  "readme": "site/index.md"
+}

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -1,26 +1,116 @@
 export {}
 
+/**
+ * The version of Graphviz used for this build.
+ */
 export const graphvizVersion: string
 
+/**
+ * The names of the {@link https://www.graphviz.org/docs/outputs/ | Graphviz output formats} supported in this build.
+ */
 export const formats: string[]
 
+/**
+ * The names of the {@link https://www.graphviz.org/docs/layouts/ | Graphviz layout engines} supported in this build.
+ */
 export const engines: string[]
 
+/**
+ * Returns a promise that resolves to an instance of the {@link Viz} class.
+ */
 export function instance(): Promise<Viz>
 
+/**
+ * The {@link Viz} class isn't exported, but it can be instantiated using the {@link instance} function.
+ */
 declare class Viz {
+  /**
+   * The version of Graphviz at runtime.
+   */
   get graphvizVersion(): string
+
+  /**
+   * The names of the {@link https://www.graphviz.org/docs/outputs/ | Graphviz output formats} supported at runtime.
+   */
   get formats(): string[]
+
+  /**
+   * The names of the {@link https://www.graphviz.org/docs/layouts/ | Graphviz layout engines} supported at runtime.
+   */
   get engines(): string[]
+
+  /**
+   * @internal
+   */
+  constructor()
+
+  /**
+   * Renders the graph described by the input and returns the result as an object.
+   *
+   * `input` may be a string in {@link https://www.graphviz.org/doc/info/lang.html | DOT syntax} or a {@link Graph | graph object}.
+   *
+   * This method does not throw an error if rendering failed, including for invalid DOT syntax, but it will throw for invalid types in input or unexpected runtime errors.
+   */
   render(input: string | Graph, options?: RenderOptions): RenderResult
+
+  /**
+   * Renders the graph described by the input for each format in `formats` and returns the result as an object. For a successful result, `output` is an object keyed by format.
+   */
   renderFormats(input: string | Graph, formats: string[], options?: RenderOptions): MultipleRenderResult
+
+  /**
+   * Renders the input and returns the result as a string. Throws an error if rendering failed.
+   */
   renderString(input: string | Graph, options?: RenderOptions): string
+
+  /**
+   * Convenience method that renders the input, parses the output, and returns an SVG element. The `format` option is ignored. Throws an error if rendering failed.
+   */
   renderSVGElement(input: string | Graph, options?: RenderOptions): SVGSVGElement
+
+  /**
+   * Convenience method that renders the input, parses the output, and returns a JSON object. The `format` option is ignored. Throws an error if rendering failed.
+   */
   renderJSON(input: string | Graph, options?: RenderOptions): object
 }
 
 export { type Viz }
 
+/**
+ * @property format
+ * The {@link https://www.graphviz.org/docs/outputs/ | Graphviz output format} to render. For example, `"dot"` or `"svg"`.
+ *
+ * @property engine
+ * The {@link https://www.graphviz.org/docs/layouts/ | Graphviz layout engine} to use for graph layout. For example, `"dot"` or `"neato"`.
+ *
+ * @property yInvert
+ * Invert y coordinates in output. This corresponds to the {@link https://www.graphviz.org/doc/info/command.html#-y | `-y`} Graphviz command-line option</a>.
+ *
+ * @property reduce
+ * Reduce the graph. This corresponds to the {@link https://www.graphviz.org/doc/info/command.html#-x | `-x`} Graphviz command-line option</a>.
+ *
+ * @property graphAttributes
+ * Sets the default graph attributes. This corresponds the {@link https://www.graphviz.org/doc/info/command.html#-G | `-G`} Graphviz command-line option</a>.
+ *
+ * @property nodeAttributes
+ * Sets the default node attributes. This corresponds the {@link https://www.graphviz.org/doc/info/command.html#-N `-N`} Graphviz command-line option</a>.
+ *
+ * @property edgeAttributes
+ * Sets the default edge attributes. This corresponds the {@link https://www.graphviz.org/doc/info/command.html#-E | `-E`} Graphviz command-line option</a>.
+ *
+ * @property images
+ * Image sizes to use when rendering nodes with <code>image</code> attributes.
+ *
+ * For example, to indicate to Graphviz that the image <code>test.png</code> has size 300x200:
+ *
+ * ```js
+ * viz.render("graph { a[image=\"test.png\"] }", {
+ *   images: [
+ *     { name: "test.png", width: 300, height: 200 }
+ *   ]
+ * });
+ * ```
+ */
 export interface RenderOptions {
   format?: string
   engine?: string
@@ -32,23 +122,38 @@ export interface RenderOptions {
   images?: ImageSize[]
 }
 
+/**
+ * The result object returned by {@link Viz.render}.
+ */
 export type RenderResult = SuccessResult | FailureResult
 
-interface SuccessResult {
+/**
+ * Returned by {@link Viz.render} if rendering was successful. `errors` may contain warning messages even if the graph rendered successfully.
+ */
+export interface SuccessResult {
   status: "success"
   output: string
   errors: RenderError[]
 }
 
-interface FailureResult {
+/**
+ * Returned by {@link Viz.render} or {@link Viz.renderFormats} if rendering failed.
+ */
+export interface FailureResult {
   status: "failure"
   output: undefined
   errors: RenderError[]
 }
 
+/**
+ * The result object returned by {@link Viz.renderFormats}.
+ */
 export type MultipleRenderResult = MultipleSuccessResult | FailureResult
 
-interface MultipleSuccessResult {
+/**
+ * Returned by {@link Viz.renderFormats} if rendering was successful. `errors` may contain warning messages even if the graph rendered successfully.
+ */
+export interface MultipleSuccessResult {
   status: "success"
   output: { [format: string]: string }
   errors: RenderError[]
@@ -59,6 +164,94 @@ export interface RenderError {
   message: string
 }
 
+/**
+ * In addition to strings in {@link https://www.graphviz.org/doc/info/lang.html | DOT syntax}, {@link Viz.render | rendering methods} accept <i>graph objects</i>.
+ *
+ * Graph objects are plain JavaScript objects, similar to {@link https://jsongraphformat.info | JSON Graph} or {@link https://github.com/dagrejs/graphlib/wiki/API-Reference#json-write | the Dagre JSON serialization}, but are specifically designed for working with Graphviz. Because of that, they use terminology from the Graphviz API (edges have a "head" and "tail", and nodes are identified with "name") and support features such as subgraphs, HTML labels, and default attributes.
+ *
+ * Some example graph objects and the corresponding graph in DOT:
+ *
+ * ## Empty directed graph
+ *
+ * ```json
+ * {}
+ * ```
+ *
+ * ```
+ * digraph { }
+ * ```
+ *
+ * ## Simple Undirected Graph
+ *
+ * ```json
+ * {
+ *   directed: false,
+ *   edges: [
+ *     { tail: "a", head: "b" },
+ *     { tail: "b", head: "c" },
+ *     { tail: "c", head: "a" }
+ *   ]
+ * }
+ * ```
+ *
+ * ```
+ * graph {
+ *   a -- b
+ *   b -- c
+ *   c -- a
+ * }
+ * ```
+ *
+ * ## Attributes, Subgraphs, HTML Labels
+ *
+ * ```json
+ * {
+ *   graphAttributes: {
+ *     rankdir: "LR"
+ *   },
+ *   nodeAttributes: {
+ *     shape: "circle"
+ *   },
+ *   nodes: [
+ *     { name: "a", attributes: { label: { html: "&lt;i&gt;A&lt;/i&gt;" }, color: "red" } },
+ *     { name: "b", attributes: { label: { html: "&lt;b&gt;A&lt;/b&gt;" }, color: "green" } }
+ *   ],
+ *   edges: [
+ *     { tail: "a", head: "b", attributes: { label: "1" } },
+ *     { tail: "b", head: "c", attributes: { label: "2", headport: "name" } }
+ *   ],
+ *   subgraphs: [
+ *     {
+ *       name: "cluster_1",
+ *       nodes: [
+ *         {
+ *           name: "c",
+ *           attributes: {
+ *             label: {
+ *               html: "&lt;table&gt;&lt;tr&gt;&lt;td&gt;test&lt;/td&gt;&lt;td port=\"name\"&gt;C&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;"
+ *             }
+ *           }
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * ```
+ * digraph {
+ *   graph [rankdir="LR"]
+ *   node [shape="circle"]
+ *   a [label=&lt;&lt;i&gt;A&lt;/i&gt;&gt;, color="red"]
+ *   b [label=&lt;&lt;b&gt;B&lt;/b&gt;&gt;, color="green"]
+ *   a -> b [label="1"]
+ *   b -> c:name [label="2"]
+ *   subgraph cluster_1 {
+ *     c [label=&lt;&lt;table&gt;&lt;tr&gt;&lt;td port="name"&gt;C&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&gt;]
+ *   }
+ * }
+ * ```
+ */
 export interface Graph {
   name?: string
   strict?: boolean
@@ -71,26 +264,26 @@ export interface Graph {
   subgraphs?: Subgraph[]
 }
 
-interface Attributes {
+export interface Attributes {
   [name: string]: string | number | boolean | HTMLString
 }
 
-interface HTMLString {
+export interface HTMLString {
   html: string
 }
 
-interface Node {
+export interface Node {
   name: string
   attributes?: Attributes
 }
 
-interface Edge {
+export interface Edge {
   tail: string
   head: string
   attributes?: Attributes
 }
 
-interface Subgraph {
+export interface Subgraph {
   name?: string
   graphAttributes?: Attributes
   nodeAttributes?: Attributes
@@ -100,7 +293,27 @@ interface Subgraph {
   subgraphs?: Subgraph[]
 }
 
-interface ImageSize {
+/**
+ * Specifies the size of an image used as a node's `image` attribute. See {@link RenderOptions.images}.
+ *
+ * `width` and `height` may be specified as numbers or strings with units: in, px, pc, pt, cm, or mm. If no units are given or measurements are given as numbers, points (pt) are used.
+ *
+ * @property name
+ * The name of the image. In addition to filenames, names that look like absolute filesystem paths or URLs can be used. For example:
+ *
+ * - `"example.png"`
+ * - `"/images/example.png"`
+ * - `"http://example.com/image.png"`
+ *
+ * Names that look like relative filesystem paths, such as `"../example.png"`, are not supported.
+ *
+ * @property width
+ * The width of the image.
+ *
+ * @property height
+ * The height of the image.
+ */
+export interface ImageSize {
   name: string,
   width: string | number,
   height: string | number


### PR DESCRIPTION
This adds the documentation from the website to the type declaration file, and configuration to generate the docs automatically using typedoc.

This should eventually replace the existing API docs in the website package.