### PR TITLE
Export the Viz class

### DIFF
--- a/packages/viz/scripts/generate-metadata.mjs
+++ b/packages/viz/scripts/generate-metadata.mjs
@@ -1,9 +1,9 @@
 import { writeFileSync } from "node:fs";
-import { Viz } from "../src/viz.mjs";
+import { VizWrapper } from "../src/viz.mjs";
 
 const args = process.argv.slice(2);
 
-const viz = new Viz();
+const viz = new VizWrapper();
 await viz.load();
 
 const code = `export const graphvizVersion = ${JSON.stringify(viz.graphvizVersion)};

--- a/packages/viz/scripts/generate-metadata.mjs
+++ b/packages/viz/scripts/generate-metadata.mjs
@@ -1,11 +1,10 @@
 import { writeFileSync } from "node:fs";
-import Module from "../lib/module.mjs";
-import Viz from "../src/viz.mjs";
-import { decode } from "../lib/encoded.mjs";
+import { Viz } from "../src/viz.mjs";
 
 const args = process.argv.slice(2);
 
-const viz = new Viz(await Module({ wasm: decode() }));
+const viz = new Viz();
+await viz.load();
 
 const code = `export const graphvizVersion = ${JSON.stringify(viz.graphvizVersion)};
 export const formats = ${JSON.stringify(viz.formats)};

--- a/packages/viz/site/index.md
+++ b/packages/viz/site/index.md
@@ -4,19 +4,15 @@ Viz.js is a WebAssembly build of Graphviz with a simple JavaScript wrapper.
 
 ### ES module
 
-<p>The Viz.js ES module is published as a single file, including its WebAssembly code. It exports a function, {@link instance}, which encapsulates decoding the WebAssembly code and instantiating the WebAssembly and Emscripten modules. This returns a promise that resolves to an instance of the {@link Viz} class, which provides methods for {@link Viz.render | rendering graphs}.</p>
-
 ```js
-import { instance } from "@viz-js/viz";
+import { Viz } from "@viz-js/viz";
 
-instance().then(viz => {
-  const svg = viz.renderSVGElement("digraph { a -> b }");
+await Viz.load();
 
-  document.getElementById("graph").appendChild(svg);
-});
+const svg = viz.renderSVGElement("digraph { a -> b }");
 ```
 
-The instance can be used to render multiple graphs.</p>
+The instance can be used to render multiple graphs.
 
 ### UMD Bundle
 

--- a/packages/viz/site/index.md
+++ b/packages/viz/site/index.md
@@ -7,16 +7,16 @@ Viz.js is a WebAssembly build of Graphviz with a simple JavaScript wrapper.
 ```js
 import { Viz } from "@viz-js/viz";
 
-await Viz.load();
+if (!Viz.isLoaded) {
+  await Viz.load();
+}
 
-const svg = viz.renderSVGElement("digraph { a -> b }");
+const svg = Viz.renderSVGElement("digraph { a -> b }");
 ```
-
-The instance can be used to render multiple graphs.
 
 ### UMD Bundle
 
-The package also includes a UMD bundle, <code>lib/viz-standalone.js</code>. This assigns the {@link instance} function to a global <code>Viz</code> object.
+The package also includes a UMD bundle, <code>lib/viz-standalone.js</code> which assigns a global `Viz` object.
 
 ```html
 <div id="graph"></div>

--- a/packages/viz/src/standalone.mjs
+++ b/packages/viz/src/standalone.mjs
@@ -1,9 +1,13 @@
-import Module from "../lib/module.mjs";
-import Viz from "./viz.mjs";
-import { decode } from "../lib/encoded.mjs";
+import { Viz as VizClass } from "./viz.mjs";
 
 export { graphvizVersion, formats, engines } from "../lib/metadata.mjs";
 
-export function instance() {
-  return Module({ wasm: decode() }).then(m => new Viz(m));
+export async function instance() {
+  const viz = new VizClass();
+  await viz.load();
+  return viz;
 }
+
+const Viz = new VizClass();
+
+export { Viz };

--- a/packages/viz/src/standalone.mjs
+++ b/packages/viz/src/standalone.mjs
@@ -1,13 +1,13 @@
-import { Viz as VizClass } from "./viz.mjs";
+import { VizWrapper } from "./viz.mjs";
 
 export { graphvizVersion, formats, engines } from "../lib/metadata.mjs";
 
 export async function instance() {
-  const viz = new VizClass();
+  const viz = new VizWrapper();
   await viz.load();
   return viz;
 }
 
-const Viz = new VizClass();
+const Viz = new VizWrapper();
 
-export { Viz };
+export { Viz, VizWrapper };

--- a/packages/viz/src/viz.mjs
+++ b/packages/viz/src/viz.mjs
@@ -1,27 +1,50 @@
+import Module from "../lib/module.mjs";
+import { decode } from "../lib/encoded.mjs";
 import { getGraphvizVersion, getPluginList, renderInput } from "./wrapper.mjs";
 
-class Viz {
-  constructor(module) {
-    this.module = module;
-  }
-
+export class Viz {
   get graphvizVersion() {
+    this.assertLoaded();
+
     return getGraphvizVersion(this.module);
   }
 
   get formats() {
+    this.assertLoaded();
+
     return getPluginList(this.module, "device");
   }
 
   get engines() {
+    this.assertLoaded();
+
     return getPluginList(this.module, "layout");
   }
 
+  get isLoaded() {
+    return typeof this.module !== "undefined";
+  }
+
+  async load() {
+    this.module = await Module({ wasm: decode() });
+    return this;
+  }
+
+  assertLoaded() {
+    if (!this.isLoaded) {
+      throw new Error("Viz is not loaded. Call `await Viz.load()` first.");
+    }
+  }
+
   renderFormats(input, formats, options = {}) {
+    this.assertLoaded();
+
     return renderInput(this.module, input, formats, { engine: "dot", ...options });
   }
 
   render(input, options = {}) {
+    this.assertLoaded();
+
     let format;
 
     if (options.format === void 0) {
@@ -60,5 +83,3 @@ class Viz {
     return JSON.parse(str);
   }
 }
-
-export default Viz;

--- a/packages/viz/src/viz.mjs
+++ b/packages/viz/src/viz.mjs
@@ -2,7 +2,7 @@ import Module from "../lib/module.mjs";
 import { decode } from "../lib/encoded.mjs";
 import { getGraphvizVersion, getPluginList, renderInput } from "./wrapper.mjs";
 
-export class Viz {
+export class VizWrapper {
   get graphvizVersion() {
     this.assertLoaded();
 

--- a/packages/viz/test/commonjs-require/index.js
+++ b/packages/viz/test/commonjs-require/index.js
@@ -1,3 +1,5 @@
-const { instance } = require("@viz-js/viz");
+const { instance, Viz } = require("@viz-js/viz");
 
 instance().then(viz => console.log(viz.renderString("digraph { a -> b }")));
+
+Viz.load().then(viz => console.log(viz.renderString("digraph { a -> b }")));

--- a/packages/viz/test/commonjs-require/package-lock.json
+++ b/packages/viz/test/commonjs-require/package-lock.json
@@ -10,7 +10,7 @@
     },
     "../..": {
       "name": "@viz-js/viz",
-      "version": "3.12.0-dev",
+      "version": "3.14.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.21.4",
@@ -19,7 +19,9 @@
         "@rollup/plugin-terser": "^0.4.1",
         "jsdom": "^21.1.1",
         "mocha": "^11.1.0",
-        "rollup": "^3.29.5"
+        "rollup": "^3.29.5",
+        "typedoc": "^0.28.5",
+        "typedoc-plugin-mdn-links": "^5.0.2"
       }
     },
     "node_modules/@viz-js/viz": {

--- a/packages/viz/test/constant.test.mjs
+++ b/packages/viz/test/constant.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { Viz } from "../src/standalone.mjs";
+
+describe("Viz", function() {
+  describe("load", function() {
+    it("returns a promise that resolves once the module is loaded", async function() {
+      assert.strictEqual(Viz.isLoaded, false);
+      assert.throws(() => Viz.render("digraph { a -> b }"));
+
+      await Viz.load();
+
+      assert.strictEqual(Viz.isLoaded, true);
+      assert.doesNotThrow(() => Viz.render("digraph { a -> b }"));
+    });
+
+    it("returns itself", async function() {
+      assert.strictEqual(await Viz.load(), Viz);
+    });
+
+    it("can be called multiple times", async function() {
+      await Viz.load();
+      await Viz.load();
+    });
+  });
+});

--- a/packages/viz/test/module-import/index.js
+++ b/packages/viz/test/module-import/index.js
@@ -1,5 +1,13 @@
 import { instance, Viz } from "@viz-js/viz";
 
-instance().then(viz => console.log(viz.renderString("digraph { a -> b }")));
+if (!Viz.loaded) {
+  console.log("Loading...");
 
-Viz.load().then(viz => console.log(viz.renderString("digraph { a -> b }")));
+  await Viz.load();
+}
+
+console.log(Viz.renderString("digraph { a -> b }"));
+
+const viz = await instance();
+
+console.log(viz.renderString("digraph { a -> b }"));

--- a/packages/viz/test/module-import/index.js
+++ b/packages/viz/test/module-import/index.js
@@ -1,3 +1,5 @@
-import { instance } from "@viz-js/viz";
+import { instance, Viz } from "@viz-js/viz";
 
 instance().then(viz => console.log(viz.renderString("digraph { a -> b }")));
+
+Viz.load().then(viz => console.log(viz.renderString("digraph { a -> b }")));

--- a/packages/viz/test/module-import/package-lock.json
+++ b/packages/viz/test/module-import/package-lock.json
@@ -10,7 +10,7 @@
     },
     "../..": {
       "name": "@viz-js/viz",
-      "version": "3.12.0-dev",
+      "version": "3.14.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.21.4",
@@ -19,7 +19,9 @@
         "@rollup/plugin-terser": "^0.4.1",
         "jsdom": "^21.1.1",
         "mocha": "^11.1.0",
-        "rollup": "^3.29.5"
+        "rollup": "^3.29.5",
+        "typedoc": "^0.28.5",
+        "typedoc-plugin-mdn-links": "^5.0.2"
       }
     },
     "node_modules/@viz-js/viz": {

--- a/packages/viz/test/standalone.test.mjs
+++ b/packages/viz/test/standalone.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import * as VizPackage from "../src/standalone.mjs";
-import Viz from "../src/viz.mjs";
+import { Viz } from "../src/viz.mjs";
 
 describe("graphvizVersion", function() {
   it("returns the Graphviz version", function() {

--- a/packages/viz/test/types/top-level.ts
+++ b/packages/viz/test/types/top-level.ts
@@ -1,4 +1,4 @@
-import { instance, graphvizVersion, formats, engines, type RenderOptions, type RenderResult, type RenderError, type Viz } from "@viz-js/viz";
+import { instance, graphvizVersion, formats, engines, Viz, type RenderOptions, type RenderResult, type RenderError } from "@viz-js/viz";
 
 let version: string = graphvizVersion;
 
@@ -9,3 +9,8 @@ let supportedFormats: Array<string> = formats;
 instance().then(viz => {
   viz.render("digraph { a -> b }");
 });
+
+const viz = new Viz();
+const loaded: boolean = viz.isLoaded;
+
+viz.load().then(() => {});

--- a/packages/viz/test/types/top-level.ts
+++ b/packages/viz/test/types/top-level.ts
@@ -1,4 +1,4 @@
-import { instance, graphvizVersion, formats, engines, Viz, type RenderOptions, type RenderResult, type RenderError } from "@viz-js/viz";
+import { instance, graphvizVersion, formats, engines, Viz, VizWrapper, type RenderOptions, type RenderResult, type RenderError } from "@viz-js/viz";
 
 let version: string = graphvizVersion;
 
@@ -10,7 +10,12 @@ instance().then(viz => {
   viz.render("digraph { a -> b }");
 });
 
-const viz = new Viz();
+Viz.load().then(viz => {
+  viz.render("digraph { a -> b }");
+  Viz.render("digraph { a -> b }");
+});
+
+const viz = new VizWrapper();
 const loaded: boolean = viz.isLoaded;
 
 viz.load().then(() => {});

--- a/packages/viz/test/types/viz.ts
+++ b/packages/viz/test/types/viz.ts
@@ -1,10 +1,10 @@
-import { instance, type Viz, type RenderResult, type MultipleRenderResult } from "@viz-js/viz";
+import { instance, Viz, VizWrapper, type RenderResult, type MultipleRenderResult } from "@viz-js/viz";
 
-export function myRender(viz: Viz, src: string): string {
+export function myRender(viz: VizWrapper, src: string): string {
   return viz.renderString(src, { graphAttributes: { label: "My graph" } });
 }
 
-instance().then(viz => {
+function testInstance(viz: VizWrapper) {
   viz.render("digraph { a -> b }");
 
   viz.render("digraph { a -> b }", { format: "svg" });
@@ -49,4 +49,13 @@ instance().then(viz => {
   let supportedEngines: Array<string> = viz.engines;
 
   let supportedFormats: Array<string> = viz.formats;
+}
+
+instance().then(viz => {
+  testInstance(viz);
+});
+
+Viz.load().then(viz => {
+  testInstance(Viz);
+  testInstance(viz);
 });

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -20,34 +20,44 @@ export const engines: string[]
  */
 export function instance(): Promise<Viz>
 
-/**
- * The {@link Viz} class isn't exported, but it can be instantiated using the {@link instance} function.
- */
-declare class Viz {
+export class Viz {
   /**
    * The version of Graphviz at runtime.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    */
   get graphvizVersion(): string
 
   /**
    * The names of the {@link https://www.graphviz.org/docs/outputs/ | Graphviz output formats} supported at runtime.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    */
   get formats(): string[]
 
   /**
    * The names of the {@link https://www.graphviz.org/docs/layouts/ | Graphviz layout engines} supported at runtime.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    */
   get engines(): string[]
 
   /**
-   * @internal
+   * Indicates whether or not the Empscripten module has been loaded.
    */
-  constructor()
+  get isLoaded(): boolean
+
+  /**
+   * Load the Emscripten module. Once loaded, {@link render | rendering methods} may be called.
+   */
+  load(): Promise<undefined>
 
   /**
    * Renders the graph described by the input and returns the result as an object.
    *
    * `input` may be a string in {@link https://www.graphviz.org/doc/info/lang.html | DOT syntax} or a {@link Graph | graph object}.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    *
    * This method does not throw an error if rendering failed, including for invalid DOT syntax, but it will throw for invalid types in input or unexpected runtime errors.
    */
@@ -55,26 +65,32 @@ declare class Viz {
 
   /**
    * Renders the graph described by the input for each format in `formats` and returns the result as an object. For a successful result, `output` is an object keyed by format.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderFormats(input: string | Graph, formats: string[], options?: RenderOptions): MultipleRenderResult
 
   /**
    * Renders the input and returns the result as a string. Throws an error if rendering failed.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderString(input: string | Graph, options?: RenderOptions): string
 
   /**
    * Convenience method that renders the input, parses the output, and returns an SVG element. The `format` option is ignored. Throws an error if rendering failed.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderSVGElement(input: string | Graph, options?: RenderOptions): SVGSVGElement
 
   /**
    * Convenience method that renders the input, parses the output, and returns a JSON object. The `format` option is ignored. Throws an error if rendering failed.
+   *
+   * Throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderJSON(input: string | Graph, options?: RenderOptions): object
 }
-
-export { type Viz }
 
 /**
  * @property format

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -16,29 +16,37 @@ export const formats: string[]
 export const engines: string[]
 
 /**
- * Returns a promise that resolves to an instance of the {@link Viz} class.
+ * Returns a promise that resolves to an instance of the {@link VizWrapper} class.
  */
-export function instance(): Promise<Viz>
+export function instance(): Promise<VizWrapper>
 
-export class Viz {
+/**
+ * An instance of {@link VizWrapper} class.
+ */
+export const Viz: VizWrapper
+
+/**
+ * Wraps the Emscripten module.
+ */
+export class VizWrapper {
   /**
    * The version of Graphviz at runtime.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   get graphvizVersion(): string
 
   /**
    * The names of the {@link https://www.graphviz.org/docs/outputs/ | Graphviz output formats} supported at runtime.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   get formats(): string[]
 
   /**
    * The names of the {@link https://www.graphviz.org/docs/layouts/ | Graphviz layout engines} supported at runtime.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   get engines(): string[]
 
@@ -49,45 +57,46 @@ export class Viz {
 
   /**
    * Load the Emscripten module. Once loaded, {@link render | rendering methods} may be called.
+   * @returns a promise that resolves to an instance of the {@link VizWrapper} class.
    */
-  load(): Promise<undefined>
+  load(): Promise<VizWrapper>
 
   /**
    * Renders the graph described by the input and returns the result as an object.
    *
    * `input` may be a string in {@link https://www.graphviz.org/doc/info/lang.html | DOT syntax} or a {@link Graph | graph object}.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
-   *
    * This method does not throw an error if rendering failed, including for invalid DOT syntax, but it will throw for invalid types in input or unexpected runtime errors.
+   *
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   render(input: string | Graph, options?: RenderOptions): RenderResult
 
   /**
    * Renders the graph described by the input for each format in `formats` and returns the result as an object. For a successful result, `output` is an object keyed by format.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderFormats(input: string | Graph, formats: string[], options?: RenderOptions): MultipleRenderResult
 
   /**
    * Renders the input and returns the result as a string. Throws an error if rendering failed.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderString(input: string | Graph, options?: RenderOptions): string
 
   /**
    * Convenience method that renders the input, parses the output, and returns an SVG element. The `format` option is ignored. Throws an error if rendering failed.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderSVGElement(input: string | Graph, options?: RenderOptions): SVGSVGElement
 
   /**
    * Convenience method that renders the input, parses the output, and returns a JSON object. The `format` option is ignored. Throws an error if rendering failed.
    *
-   * Throws an error if the promise returned by {@link load} has not yet resolved.
+   * @throws an error if the promise returned by {@link load} has not yet resolved.
    */
   renderJSON(input: string | Graph, options?: RenderOptions): object
 }


### PR DESCRIPTION
This adds a constant called `Viz` as an export, and moves loading the Emscripten module to a new `load()` method, which returns a promise once the module has loaded. Methods like `render()` that depend on the Emscripten module will now throw an error if the module hasn't yet loaded. Finally, a new `isLoaded` getter can be used to check whether or not the module is already loaded.

Example usage:

```js
import { Viz } from "@viz-js/viz";

if (!Viz.isLoaded) {
  await Viz.load();
}

const result = Viz.render("digraph { a -> b }");
```

Rationale for this change:

- Simplifies reusing the Emscripten module instance. Calling code would have to stash the instance somewhere.
- This API is more like what other Emscripten wrapper packages offer. (For example, [Herb](https://herb-tools.dev/).)
- The name of the currently exported "instance" method is far too generic. This can be worked around by using a namespace import, for example, but just exporting the `Viz` constant is easier to document.

The behavior of `instance()` is the same as before, but I plan to mark that function as deprecated.