### PR TITLE
Add @lezer/lr dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6668,7 +6668,7 @@
     },
     "packages/viz": {
       "name": "@viz-js/viz",
-      "version": "3.12.0-dev",
+      "version": "3.13.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.21.4",

--- a/packages/lang-dot/package.json
+++ b/packages/lang-dot/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@codemirror/language": "^6.8.0",
     "@lezer/common": "^1.0.3",
+    "@lezer/lr": "^1.4.2",
     "@lezer/highlight": "^1.1.6",
     "@lezer/xml": "^1.0.2"
   },


### PR DESCRIPTION
It appears a recent change in codemirror / lezer have moved the `@lezer/lr` package out and it now needs to be a direct dependecy.

This fixes errors like this:
```
[vite]: Rollup failed to resolve import "@lezer/lr"
```
