### PR TITLE
Add --ignore-scripts option to npm clean-install commands

### DIFF
--- a/.github/workflows/lang-dot-build.yml
+++ b/.github/workflows/lang-dot-build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: "Run build and test"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           npm run build
           npm run test
         working-directory: packages/lang-dot
@@ -48,11 +48,11 @@ jobs:
 
       - name: "Install in package directory"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
         working-directory: packages/lang-dot
 
       - name: "Run check-types"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           npm run check-types
         working-directory: packages/lang-dot/test/types

--- a/.github/workflows/viz-build.yml
+++ b/.github/workflows/viz-build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Build"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           test -f lib/backend.js && touch lib/backend.js
           make
         working-directory: packages/viz
@@ -74,7 +74,7 @@ jobs:
 
       - name: "Run tests"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           npm run test
         working-directory: packages/viz
 
@@ -101,13 +101,13 @@ jobs:
 
       - name: "Run module-import test"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           node index.js
         working-directory: packages/viz/test/module-import
 
       - name: "Run commonjs-require test"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           node index.js
         working-directory: packages/viz/test/commonjs-require
 
@@ -123,12 +123,12 @@ jobs:
 
       - name: "Install in package directory"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
         working-directory: packages/viz
 
       - name: "Run check-types"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           npm run check-types
           npm run check-types-node
         working-directory: packages/viz/test/types

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "20.x"
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
         working-directory: website
 
       - name: Setup Pages

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -26,6 +26,6 @@ jobs:
 
       - name: "Run tests"
         run: |
-          npm clean-install
+          npm clean-install --ignore-scripts
           npm run test
         working-directory: website


### PR DESCRIPTION
No usage of `npm clean-install` expects to run postinstall scripts as far as I know, so this explicitly ignores them.