### PR TITLE
Fix some graph object issues

### DIFF
--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix that default attributes were added incorrectly, and would appear on the root graph as well as subgraphs.
 * For graph object input, fix that subgraphs without names were given the name "undefined", and reject nodes and edges without names.
 
 ## 3.22.0

--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* For graph object input, fix that subgraphs without names were given the name "undefined", and reject nodes and edges without names.
+
 ## 3.22.0
 
 * Update Graphviz to 14.0.5.

--- a/packages/viz/backend/viz.c
+++ b/packages/viz/backend/viz.c
@@ -139,16 +139,25 @@ Agraph_t *viz_add_subgraph(Agraph_t *g, char *name) {
 
 EMSCRIPTEN_KEEPALIVE
 void viz_set_default_graph_attribute(Agraph_t *graph, char *name, char *value) {
+  if (agattr(graph, AGRAPH, name, NULL) == NULL) {
+    agattr(graph, AGRAPH, name, "");
+  }
   agattr(graph, AGRAPH, name, value);
 }
 
 EMSCRIPTEN_KEEPALIVE
 void viz_set_default_node_attribute(Agraph_t *graph, char *name, char *value) {
+  if (agattr(graph, AGNODE, name, NULL) == NULL) {
+    agattr(graph, AGNODE, name, "");
+  }
   agattr(graph, AGNODE, name, value);
 }
 
 EMSCRIPTEN_KEEPALIVE
 void viz_set_default_edge_attribute(Agraph_t *graph, char *name, char *value) {
+  if (agattr(graph, AGEDGE, name, NULL) == NULL) {
+    agattr(graph, AGEDGE, name, "");
+  }
   agattr(graph, AGEDGE, name, value);
 }
 

--- a/packages/viz/src/wrapper.js
+++ b/packages/viz/src/wrapper.js
@@ -195,6 +195,10 @@ function readGraph(module, graphPointer, graphData) {
 
   if (graphData.nodes) {
     graphData.nodes.forEach(nodeData => {
+      if (typeof nodeData.name === "undefined") {
+        throw new Error("nodes must have a name");
+      }
+
       const nodePointer = module.ccall("viz_add_node", "number", ["number", "string"], [graphPointer, String(nodeData.name)]);
 
       if (nodeData.attributes) {
@@ -205,6 +209,14 @@ function readGraph(module, graphPointer, graphData) {
 
   if (graphData.edges) {
     graphData.edges.forEach(edgeData => {
+      if (typeof edgeData.tail === "undefined") {
+        throw new Error("edges must have a tail");
+      }
+
+      if (typeof edgeData.head === "undefined") {
+        throw new Error("edges must have a head");
+      }
+
       const edgePointer = module.ccall("viz_add_edge", "number", ["number", "string", "string"], [graphPointer, String(edgeData.tail), String(edgeData.head)]);
 
       if (edgeData.attributes) {
@@ -215,7 +227,7 @@ function readGraph(module, graphPointer, graphData) {
 
   if (graphData.subgraphs) {
     graphData.subgraphs.forEach(subgraphData => {
-      const subgraphPointer = module.ccall("viz_add_subgraph", "number", ["number", "string"], [graphPointer, String(subgraphData.name)]);
+      const subgraphPointer = module.ccall("viz_add_subgraph", "number", ["number", "string"], [graphPointer, typeof subgraphData.name !== "undefined" ? String(subgraphData.name) : 0]);
 
       readGraph(module, subgraphPointer, subgraphData);
     });

--- a/packages/viz/test/graph-objects.test.js
+++ b/packages/viz/test/graph-objects.test.js
@@ -211,5 +211,78 @@ describe("Viz", function() {
         errors: []
       });
     });
+
+    it("throws for a node without a name", function() {
+      assert.throws(() => {
+        viz.render({
+          nodes: [
+            {}
+          ]
+        });
+      });
+    });
+
+    it("throws for an edge without tail or head", function() {
+      assert.throws(() => {
+        viz.render({
+          edges: [
+            {}
+          ]
+        });
+      });
+
+      assert.throws(() => {
+        viz.render({
+          edges: [
+            { tail: "a" }
+          ]
+        });
+      });
+
+      assert.throws(() => {
+        viz.render({
+          edges: [
+            { head: "b" }
+          ]
+        });
+      });
+    });
+
+    it("accepts a subgraph without a name", function() {
+      const result = viz.render({
+        subgraphs: [
+          {
+            nodes: [
+              { name: "a" }
+            ]
+          },
+          {
+            nodes: [
+              { name: "b" }
+            ]
+          }
+        ]
+      });
+
+      assert.deepStrictEqual(result, {
+        status: "success",
+        output: `digraph {
+	graph [bb="0,0,126,36"];
+	node [label="\\N"];
+	{
+		a	[height=0.5,
+			pos="27,18",
+			width=0.75];
+	}
+	{
+		b	[height=0.5,
+			pos="99,18",
+			width=0.75];
+	}
+}
+`,
+        errors: []
+      });
+    });
   });
 });

--- a/packages/viz/test/graph-objects.test.js
+++ b/packages/viz/test/graph-objects.test.js
@@ -284,5 +284,44 @@ describe("Viz", function() {
         errors: []
       });
     });
+
+    it("applies subgraph attributes correctly", function() {
+      const result = viz.render({
+        subgraphs: [
+          {
+            graphAttributes: {
+              color: "red"
+            },
+            nodeAttributes: {
+              color: "green"
+            },
+            edgeAttributes: {
+              color: "blue"
+            },
+            nodes: [
+              { name: "a" }
+            ]
+          }
+        ]
+      });
+
+      assert.deepStrictEqual(result, {
+        status: "success",
+        output: `digraph {
+	graph [bb="0,0,54,36"];
+	node [label="\\N"];
+	{
+		graph [color=red];
+		node [color=green];
+		edge [color=blue];
+		a	[height=0.5,
+			pos="27,18",
+			width=0.75];
+	}
+}
+`,
+        errors: []
+      });
+    });
   });
 });


### PR DESCRIPTION
I found some problems with graph objects.

First, nodes without a name would be accepted in graph objects, and edges without a head or tail would be accepted, replacing the missing name with "undefined".

For example, this graph object would be accepted, but rendered with a node named "undefined". Attempting to render a graph like this now throws an error. This is consistent with [the type definition for graph objects](https://viz-js.com/api/#viz.Graph).

```js
{
  nodes: [
    {}
  ]
}
```

Second, subgraphs without a name would be given the name "undefined". The subgraph in this graph object has no name, and should not have one when rendered as DOT. Again, this is consistent with the type definition for graph objects.

```js
{
  subgraphs: [
    {
      nodes: [
        { name: "a" }
      ]
    }
  ]
}
```

Third, default graph, node, and edge attributes were added incorrectly, and some values would be added to the root graph as well as a subgraph. In this graph, only the nodes in the subgraph should have the green color:

```js
{
  nodes: [
    {
      name: "a"
    }
  ]
  subgraphs: [
    {
      nodeAttributes: {
        color: "green"
      },
      nodes: [
        {
          name: "b",
        }
      ]
    }
  ]
}
```
