### PR TITLE
Implement custom text measurement

### DIFF
--- a/packages/viz/backend/viz.c
+++ b/packages/viz/backend/viz.c
@@ -1,6 +1,9 @@
 #include <gvc.h>
+#include <gvplugin_textlayout.h>
 #include <emscripten.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 
 extern int Y_invert;
 extern unsigned char Reduce;
@@ -9,10 +12,125 @@ extern gvplugin_library_t gvplugin_core_LTX_library;
 extern gvplugin_library_t gvplugin_dot_layout_LTX_library;
 extern gvplugin_library_t gvplugin_neato_layout_LTX_library;
 
+static char *viz_textlayout_fontpath = NULL;
+
+EM_JS(int, viz_textlayout_measure, (const char *text, const char *font_name,
+                                   double font_size, unsigned int flags,
+                                   double *width, double *height,
+                                   double *yoffset_layout,
+                                   double *yoffset_centerline), {
+  const measure = Module["vizjsTextMeasure"];
+
+  if (typeof measure !== "function") {
+    return 0;
+  }
+
+  let result;
+
+  try {
+    result = measure({
+      text: UTF8ToString(text),
+      fontName: UTF8ToString(font_name),
+      fontSize: font_size,
+      bold: !!(flags & (1 << 0)),
+      italic: !!(flags & (1 << 1)),
+      underline: !!(flags & (1 << 2)),
+      superscript: !!(flags & (1 << 3)),
+      subscript: !!(flags & (1 << 4)),
+      strikethrough: !!(flags & (1 << 5)),
+      overline: !!(flags & (1 << 6)),
+    });
+  } catch (error) {
+    const message =
+      error && typeof error.message === "string"
+        ? error.message
+        : String(error);
+    Module["stderrMessages"].push(`text measurement failed: ${message}`);
+    return 0;
+  }
+
+  if (result == null || typeof result !== "object") {
+    return 0;
+  }
+
+  if (typeof result.width !== "number" || typeof result.height !== "number") {
+    return 0;
+  }
+
+  setValue(width, result.width, "double");
+  setValue(height, result.height, "double");
+
+  setValue(
+    yoffset_layout,
+    typeof result.yoffsetLayout === "number" ? result.yoffsetLayout : font_size,
+    "double"
+  );
+  setValue(
+    yoffset_centerline,
+    typeof result.yoffsetCenterline === "number" ? result.yoffsetCenterline : 0.05 * font_size,
+    "double"
+  );
+
+  return 1;
+});
+
+static bool viz_textlayout(textspan_t *span, char **fontpath) {
+  double width = 0.0;
+  double height = 0.0;
+  double yoffset_layout = 0.0;
+  double yoffset_centerline = 0.0;
+
+  if (span == NULL || span->font == NULL || span->font->name == NULL || span->str == NULL) {
+    return false;
+  }
+
+  if (!viz_textlayout_measure(span->str, span->font->name, span->font->size,
+                              span->font->flags, &width, &height,
+                              &yoffset_layout, &yoffset_centerline)) {
+    return false;
+  }
+
+  span->layout = NULL;
+  span->free_layout = NULL;
+  span->size.x = width;
+  span->size.y = height;
+  span->yoffset_layout = yoffset_layout;
+  span->yoffset_centerline = yoffset_centerline;
+
+  if (fontpath != NULL) {
+    if (viz_textlayout_fontpath == NULL) {
+      viz_textlayout_fontpath = strdup("[viz-js textMeasure]");
+      if (viz_textlayout_fontpath == NULL) {
+        return false;
+      }
+    }
+    *fontpath = viz_textlayout_fontpath;
+  }
+
+  return true;
+}
+
+static gvtextlayout_engine_t viz_textlayout_engine = {
+  viz_textlayout,
+};
+
+static gvplugin_installed_t gvtextlayout_viz_types[] = {
+  {0, "textlayout", 20, &viz_textlayout_engine, NULL},
+  {0, NULL, 0, NULL, NULL},
+};
+
+static gvplugin_api_t viz_apis[] = {
+  {API_textlayout, gvtextlayout_viz_types},
+  {(api_t)0, 0},
+};
+
+gvplugin_library_t gvplugin_viz_LTX_library = { "viz", viz_apis };
+
 lt_symlist_t lt_preloaded_symbols[] = {
   { "gvplugin_core_LTX_library", &gvplugin_core_LTX_library},
   { "gvplugin_dot_layout_LTX_library", &gvplugin_dot_layout_LTX_library},
   { "gvplugin_neato_layout_LTX_library", &gvplugin_neato_layout_LTX_library},
+  { "gvplugin_viz_LTX_library", &gvplugin_viz_LTX_library},
   { 0, 0 }
 };
 

--- a/packages/viz/src/wrapper.js
+++ b/packages/viz/src/wrapper.js
@@ -29,10 +29,12 @@ export function getPluginList(module, kind) {
 
 export function renderInput(module, input, formats, options) {
   let graphPointer, contextPointer, resultPointer, imageFilePaths;
+  const previousTextMeasure = module["vizjsTextMeasure"];
 
   try {
     module["agerrMessages"] = [];
     module["stderrMessages"] = [];
+    module["vizjsTextMeasure"] = resolveTextMeasure(options);
 
     imageFilePaths = createImageFiles(module, options.images);
 
@@ -125,7 +127,80 @@ export function renderInput(module, input, formats, options) {
     if (imageFilePaths) {
       removeImageFiles(module, imageFilePaths);
     }
+
+    module["vizjsTextMeasure"] = previousTextMeasure;
   }
+}
+
+function resolveTextMeasure(options) {
+  if (typeof options.textMeasure === "function") {
+    return options.textMeasure;
+  }
+
+  return getDefaultTextMeasure();
+}
+
+let defaultTextMeasure;
+
+function getDefaultTextMeasure() {
+  if (defaultTextMeasure !== undefined) {
+    return defaultTextMeasure;
+  }
+
+  if (typeof OffscreenCanvas !== "undefined") {
+    const canvas = new OffscreenCanvas(1, 1);
+    const context = canvas.getContext("2d");
+
+    if (context) {
+      defaultTextMeasure = createBrowserTextMeasure(context);
+      return defaultTextMeasure;
+    }
+  }
+
+  if (typeof document !== "undefined" && typeof document.createElement === "function") {
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+
+    if (context) {
+      defaultTextMeasure = createBrowserTextMeasure(context);
+      return defaultTextMeasure;
+    }
+  }
+
+  defaultTextMeasure = null;
+  return defaultTextMeasure;
+}
+
+function createBrowserTextMeasure(context) {
+  const pxPerPoint = 96 / 72;
+  const pointPerPixel = 72 / 96;
+
+  return ({ text, fontName, fontSize, bold, italic }) => {
+    const cssFontSize = fontSize * pxPerPoint;
+    const style = italic ? "italic " : "";
+    const weight = bold ? "bold " : "";
+    const family = JSON.stringify(fontName);
+
+    context.font = `${style}${weight}${cssFontSize}px ${family}`;
+    context.textBaseline = "alphabetic";
+
+    const metrics = context.measureText(text);
+    const ascent =
+      typeof metrics.actualBoundingBoxAscent === "number"
+        ? metrics.actualBoundingBoxAscent
+        : cssFontSize * 0.8;
+    const descent =
+      typeof metrics.actualBoundingBoxDescent === "number"
+        ? metrics.actualBoundingBoxDescent
+        : cssFontSize * 0.2;
+
+    return {
+      width: metrics.width * pointPerPixel,
+      height: (ascent + descent) * pointPerPixel,
+      yoffsetLayout: ascent * pointPerPixel,
+      yoffsetCenterline: descent * 0.5 * pointPerPixel,
+    };
+  };
 }
 
 function parseErrorMessages(module) {

--- a/packages/viz/test/text-measure.test.js
+++ b/packages/viz/test/text-measure.test.js
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { instance } from "../src/index.js";
+
+describe("Viz", function() {
+  describe("textMeasure", function() {
+    it("uses custom text measurement during layout", async function() {
+      const viz = await instance();
+      const input = 'digraph { node [shape=box fontname="monospace" fontsize=10]; a [label="MMMM"]; }';
+
+      const baseline = viz.renderString(input);
+      const measured = viz.renderString(input, {
+        textMeasure({ text, fontName, fontSize }) {
+          assert.equal(text, "MMMM");
+          assert.equal(fontName, "monospace");
+          assert.equal(fontSize, 10);
+
+          return {
+            width: 500,
+            height: 20,
+            yoffsetLayout: 15,
+            yoffsetCenterline: 1,
+          };
+        },
+      });
+
+      const baselineWidth = extractNodeWidth(baseline);
+      const measuredWidth = extractNodeWidth(measured);
+
+      assert.ok(measuredWidth > baselineWidth + 5, `${measuredWidth} <= ${baselineWidth}`);
+    });
+  });
+});
+
+function extractNodeWidth(dot) {
+  const match = dot.match(/\bwidth=([0-9.]+)/);
+
+  assert.ok(match, `width not found in:\n${dot}`);
+
+  return Number(match[1]);
+}

--- a/packages/viz/types/index.d.ts
+++ b/packages/viz/types/index.d.ts
@@ -120,6 +120,7 @@ export interface RenderOptions {
   nodeAttributes?: Attributes
   edgeAttributes?: Attributes
   images?: ImageSize[]
+  textMeasure?: TextMeasure
 }
 
 /**
@@ -165,8 +166,31 @@ export interface SVGRenderOptions {
   nodeAttributes?: Attributes
   edgeAttributes?: Attributes
   images?: ImageSize[]
+  textMeasure?: TextMeasure
   trustedTypePolicy?: object
 }
+
+export interface TextMeasureInput {
+  text: string
+  fontName: string
+  fontSize: number
+  bold: boolean
+  italic: boolean
+  underline: boolean
+  superscript: boolean
+  subscript: boolean
+  strikethrough: boolean
+  overline: boolean
+}
+
+export interface TextMeasureResult {
+  width: number
+  height: number
+  yoffsetLayout?: number
+  yoffsetCenterline?: number
+}
+
+export type TextMeasure = (input: TextMeasureInput) => TextMeasureResult | null | undefined
 
 /**
  * The result object returned by {@link Viz.render}.


### PR DESCRIPTION
This vibe-coded PR allows Viz.js to get more accurate text measurement information from the browser. Feel free to ignore this PR; I'm just opening it since this is the easiest place to put this code in case I want to refer back to it later.