### PR TITLE
Default attributes aren't applied correctly

### DIFF
--- a/packages/viz/CHANGELOG.md
+++ b/packages/viz/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix application of the default attribute options. (#380)
 * Update Expat to 2.8.1.
 
 ## 3.26.0

--- a/packages/viz/backend/viz.c
+++ b/packages/viz/backend/viz.c
@@ -74,9 +74,11 @@ Agraph_t *viz_read_one_graph(char *string) {
   Agraph_t *graph = NULL;
   Agraph_t *other_graph = NULL;
 
-  // Workaround for #218. Set the global default node label.
+  // Set the global default node label
 
-  agattr(NULL, AGNODE, "label", "\\N");
+  if (!agattr_text(NULL, AGNODE, "label", 0)) {
+    agattr_text(NULL, AGNODE, "label", "\\N");
+  }
 
   // Reset errors
 
@@ -137,28 +139,38 @@ Agraph_t *viz_add_subgraph(Agraph_t *g, char *name) {
   return agsubg(g, name, true);
 }
 
-EMSCRIPTEN_KEEPALIVE
-void viz_set_default_graph_attribute(Agraph_t *graph, char *name, char *value) {
-  if (agattr(graph, AGRAPH, name, NULL) == NULL) {
-    agattr(graph, AGRAPH, name, "");
+// Add an attribute with the name and value if there is none with that name
+void add_attribute(void *obj, char *name, const char *default_value) {
+  char *value = agget(obj, name);
+
+  if (value == NULL || strcmp(value, "") == 0) {
+    agsafeset(obj, name, default_value, "");
   }
-  agattr(graph, AGRAPH, name, value);
 }
 
 EMSCRIPTEN_KEEPALIVE
-void viz_set_default_node_attribute(Agraph_t *graph, char *name, char *value) {
-  if (agattr(graph, AGNODE, name, NULL) == NULL) {
-    agattr(graph, AGNODE, name, "");
+void viz_set_default_graph_attribute(Agraph_t *graph, char *name, char *default_value) {
+  add_attribute(graph, name, default_value);
+
+  for (Agraph_t *subgraph = agfstsubg(graph); subgraph; subgraph = agnxtsubg(subgraph)) {
+    add_attribute(subgraph, name, default_value);
   }
-  agattr(graph, AGNODE, name, value);
 }
 
 EMSCRIPTEN_KEEPALIVE
-void viz_set_default_edge_attribute(Agraph_t *graph, char *name, char *value) {
-  if (agattr(graph, AGEDGE, name, NULL) == NULL) {
-    agattr(graph, AGEDGE, name, "");
+void viz_set_default_node_attribute(Agraph_t *graph, char *name, char *default_value) {
+  for (Agnode_t *node = agfstnode(graph); node; node = agnxtnode(graph, node)) {
+    add_attribute(node, name, default_value);
   }
-  agattr(graph, AGEDGE, name, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void viz_set_default_edge_attribute(Agraph_t *graph, char *name, char *default_value) {
+  for (Agnode_t *node = agfstnode(graph); node; node = agnxtnode(graph, node)) {
+    for (Agedge_t *edge = agfstout(graph, node); edge; edge = agnxtout(graph, edge)) {
+      add_attribute(edge, name, default_value);
+    }
+  }
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/packages/viz/src/wrapper.js
+++ b/packages/viz/src/wrapper.js
@@ -191,8 +191,6 @@ function readObjectInput(module, object, options) {
 }
 
 function readGraph(module, graphPointer, graphData) {
-  setDefaultAttributes(module, graphPointer, graphData);
-
   if (graphData.nodes) {
     graphData.nodes.forEach(nodeData => {
       if (typeof nodeData.name === "undefined") {
@@ -232,6 +230,8 @@ function readGraph(module, graphPointer, graphData) {
       readGraph(module, subgraphPointer, subgraphData);
     });
   }
+
+  setDefaultAttributes(module, graphPointer, graphData);
 }
 
 function setDefaultAttributes(module, graphPointer, data) {

--- a/packages/viz/test/attributes.test.js
+++ b/packages/viz/test/attributes.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import * as VizPackage from "../src/index.js";
+
+describe("Viz", function() {
+  let viz;
+
+  beforeEach(async function() {
+    viz = await VizPackage.instance();
+  });
+
+  beforeEach(function() {
+    const window = (new JSDOM()).window;
+    global.DOMParser = window.DOMParser;
+  });
+
+  afterEach(function() {
+    delete global.DOMParser;
+  });
+
+  describe("default attributes", function() {
+    it("can be set for graphs, nodes, and edges", function() {
+      const src = `digraph {
+        graph [id=g]
+        a [id=a]
+        b [id=b, color=blue]
+        a -> b [id=e]
+      }`;
+
+      const svg = viz.renderSVGElement(src, {
+        graphAttributes: {
+          bgcolor: "pink"
+        },
+        nodeAttributes: {
+          color: "green"
+        },
+        edgeAttributes: {
+          color: "yellow"
+        }
+      });
+
+      assert.ok(svg.querySelector("#g > polygon[fill=pink]"));
+      assert.ok(svg.querySelector("#a > ellipse[stroke=green]"));
+      assert.ok(svg.querySelector("#b > ellipse[stroke=blue]"));
+      assert.ok(svg.querySelector("#e > path[stroke=yellow]"));
+
+      const svg2 = viz.renderSVGElement(src, {
+        graphAttributes: {
+          bgcolor: "yellow"
+        },
+        nodeAttributes: {
+          color: "red"
+        },
+        edgeAttributes: {
+          color: "orange"
+        }
+      });
+
+      assert.ok(svg2.querySelector("#g > polygon[fill=yellow]"));
+      assert.ok(svg2.querySelector("#a > ellipse[stroke=red]"));
+      assert.ok(svg2.querySelector("#b > ellipse[stroke=blue]"));
+      assert.ok(svg2.querySelector("#e > path[stroke=orange]"));
+    });
+
+    it("can be html strings", function() {
+      const svg = viz.renderSVGElement("digraph { a -> b [id=e] }", {
+        edgeAttributes: {
+          label: { html: "<b>test</b>" }
+        }
+      });
+
+      assert.strictEqual(svg.querySelector("#e > text[font-weight=bold]").textContent, "test");
+    });
+  });
+});

--- a/packages/viz/test/graph-objects.test.js
+++ b/packages/viz/test/graph-objects.test.js
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
 import * as VizPackage from "../src/index.js";
+
+function textContents(svg, selector) {
+  return Array.from(svg.querySelectorAll(selector)).map(e => e.textContent);
+}
 
 describe("Viz", function() {
   let viz;
@@ -8,101 +13,48 @@ describe("Viz", function() {
     viz = await VizPackage.instance();
   });
 
+  beforeEach(function() {
+    const window = (new JSDOM()).window;
+    global.DOMParser = window.DOMParser;
+  });
+
+  afterEach(function() {
+    delete global.DOMParser;
+  });
+
   describe("rendering graph objects", function() {
     it("empty graph", function() {
-      const result = viz.render({});
+      const svg = viz.renderSVGElement({});
 
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `digraph {
-	graph [bb="0,0,0,0"];
-	node [label="\\N"];
-}
-`,
-        errors: []
-      });
-    });
-
-    it("attributes in options override options in input", function() {
-      const result = viz.render(
-        {
-          nodeAttributes: {
-            shape: "rectangle"
-          }
-        },
-        {
-          nodeAttributes: {
-            shape: "circle"
-          }
-        }
-      );
-
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `digraph {
-	graph [bb="0,0,0,0"];
-	node [label="\\N",
-		shape=circle
-	];
-}
-`,
-        errors: []
-      });
+      assert.deepStrictEqual(textContents(svg, ".edge title"), []);
+      assert.deepStrictEqual(textContents(svg, ".node text"), []);
     });
 
     it("just edges", function() {
-      const result = viz.render({
+      const svg = viz.renderSVGElement({
         edges: [
           { tail: "a", head: "b" }
         ]
       });
 
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `digraph {
-	graph [bb="0,0,54,108"];
-	node [label="\\N"];
-	a	[height=0.5,
-		pos="27,90",
-		width=0.75];
-	b	[height=0.5,
-		pos="27,18",
-		width=0.75];
-	a -> b	[pos="e,27,36.104 27,71.697 27,64.407 27,55.726 27,47.536"];
-}
-`,
-        errors: []
-      });
+      assert.deepStrictEqual(textContents(svg, ".edge title"), ["a->b"]);
+      assert.deepStrictEqual(textContents(svg, ".node text"), ["a", "b"]);
     });
 
     it("undirected graph", function() {
-      const result = viz.render({
+      const svg = viz.renderSVGElement({
         directed: false,
         edges: [
           { tail: "a", head: "b" }
         ]
       });
 
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `graph {
-	graph [bb="0,0,54,108"];
-	node [label="\\N"];
-	a	[height=0.5,
-		pos="27,90",
-		width=0.75];
-	b	[height=0.5,
-		pos="27,18",
-		width=0.75];
-	a -- b	[pos="27,71.697 27,60.846 27,46.917 27,36.104"];
-}
-`,
-        errors: []
-      });
+      assert.deepStrictEqual(textContents(svg, ".edge title"), ["a--b"]);
+      assert.deepStrictEqual(textContents(svg, ".node text"), ["a", "b"]);
     });
 
     it("html attributes", function() {
-      const result = viz.render({
+      const svg = viz.renderSVGElement({
         nodes: [
           {
             name: "a",
@@ -113,27 +65,62 @@ describe("Viz", function() {
         ]
       });
 
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `digraph {
-	graph [bb="0,0,54,36"];
-	a	[height=0.5,
-		label=<<b>A</b>>,
-		pos="27,18",
-		width=0.75];
-}
-`,
-        errors: []
+      assert.deepStrictEqual(textContents(svg, ".node text[font-weight=bold]"), ["A"]);
+    });
+
+    it("default attributes in graph", function() {
+      const svg = viz.renderSVGElement({
+        nodes: [
+          {
+            name: "a",
+            attributes: {
+              id: "a",
+              shape: "rectangle"
+            }
+          }
+        ],
+        nodeAttributes: {
+          shape: "circle",
+          color: "blue"
+        }
       });
+
+      assert.deepStrictEqual(textContents(svg, ".node text"), ["a"]);
+
+      assert.ok(svg.querySelector("#a polygon[stroke=blue]"));
+    });
+
+    it("default attributes in options", function() {
+      const svg = viz.renderSVGElement({
+        nodes: [
+          {
+            name: "a",
+            attributes: {
+              shape: "rectangle"
+            }
+          }
+        ]
+      },
+      {
+        nodeAttributes: {
+          shape: "circle",
+          color: "blue"
+        }
+      });
+
+      assert.deepStrictEqual(textContents(svg, ".node text"), ["a"]);
+
+      assert.ok(svg.querySelector(".node > polygon[stroke=blue]"));
     });
 
     it("default attributes, nodes, edges, and nested subgraphs", function() {
-      const result = viz.render({
+      const svg = viz.renderSVGElement({
         graphAttributes: {
+          id: "g",
           rankdir: "LR"
         },
         nodeAttributes: {
-          shape: "circle"
+          shape: "rectangle"
         },
         nodes: [
           { name: "a", attributes: { label: "A", color: "red" } },
@@ -164,52 +151,9 @@ describe("Viz", function() {
         ]
       });
 
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `digraph {
-	graph [bb="0,0,297.04,84",
-		rankdir=LR
-	];
-	node [shape=circle];
-	subgraph cluster_1 {
-		graph [bb="150.02,8,289.04,76"];
-		subgraph cluster_2 {
-			graph [bb="229.02,16,281.04,68"];
-			d	[color=orange,
-				height=0.50029,
-				label=D,
-				pos="255.03,42",
-				width=0.50029];
-		}
-		c	[color=blue,
-			height=0.5,
-			label=C,
-			pos="176.02,42",
-			width=0.5];
-		c -> d	[label=3,
-			lp="215.52,50.4",
-			pos="e,236.63,42 194.5,42 203.55,42 214.85,42 225.17,42"];
-	}
-	a	[color=red,
-		height=0.50029,
-		label=A,
-		pos="18.01,42",
-		width=0.50029];
-	b	[color=green,
-		height=0.5,
-		label=B,
-		pos="97.021,42",
-		width=0.5];
-	a -> b	[label=1,
-		lp="57.521,50.4",
-		pos="e,78.615,42 36.485,42 45.544,42 56.842,42 67.155,42"];
-	b -> c	[label=2,
-		lp="136.52,50.4",
-		pos="e,157.62,42 115.49,42 124.55,42 135.85,42 146.16,42"];
-}
-`,
-        errors: []
-      });
+      assert.deepStrictEqual(textContents(svg, ".cluster title"), ["cluster_1", "cluster_2"]);
+      assert.deepStrictEqual(textContents(svg, ".edge title"), ["a->b", "b->c", "c->d"]);
+      assert.deepStrictEqual(textContents(svg, ".node title"), ["a", "b", "c", "d"]);
     });
 
     it("throws for a node without a name", function() {
@@ -249,7 +193,7 @@ describe("Viz", function() {
     });
 
     it("accepts a subgraph without a name", function() {
-      const result = viz.render({
+      const svg = viz.renderSVGElement({
         subgraphs: [
           {
             nodes: [
@@ -264,32 +208,19 @@ describe("Viz", function() {
         ]
       });
 
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `digraph {
-	graph [bb="0,0,126,36"];
-	node [label="\\N"];
-	{
-		a	[height=0.5,
-			pos="27,18",
-			width=0.75];
-	}
-	{
-		b	[height=0.5,
-			pos="99,18",
-			width=0.75];
-	}
-}
-`,
-        errors: []
-      });
+      assert.deepStrictEqual(textContents(svg, ".node text"), ["a", "b"]);
     });
 
     it("applies subgraph attributes correctly", function() {
-      const result = viz.render({
+      const svg = viz.renderSVGElement({
+        nodes: [
+          { name: "a", attributes: { id: "a" } }
+        ],
         subgraphs: [
           {
             graphAttributes: {
+              cluster: true,
+              id: "subg",
               color: "red"
             },
             nodeAttributes: {
@@ -299,29 +230,21 @@ describe("Viz", function() {
               color: "blue"
             },
             nodes: [
-              { name: "a" }
+              { name: "b", attributes: { id: "b" } },
+              { name: "c", attributes: { id: "c" } }
+            ],
+            edges: [
+              { tail: "b", head: "c", attributes: { id: "e" } }
             ]
           }
         ]
       });
 
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `digraph {
-	graph [bb="0,0,54,36"];
-	node [label="\\N"];
-	{
-		graph [color=red];
-		node [color=green];
-		edge [color=blue];
-		a	[height=0.5,
-			pos="27,18",
-			width=0.75];
-	}
-}
-`,
-        errors: []
-      });
+      assert.ok(svg.querySelector("#subg > polygon[stroke=red]"));
+      assert.ok(svg.querySelector("#a > ellipse[stroke=black]"));
+      assert.ok(svg.querySelector("#b > ellipse[stroke=green]"));
+      assert.ok(svg.querySelector("#c > ellipse[stroke=green]"));
+      assert.ok(svg.querySelector("#e > path[stroke=blue]"));
     });
   });
 });

--- a/packages/viz/test/render-unwrapped.test.js
+++ b/packages/viz/test/render-unwrapped.test.js
@@ -62,8 +62,19 @@ describe("Viz", function() {
 
     it("returns an SVG element", function() {
       const svg = viz.renderSVGElement("digraph { a -> b }");
+
       assert.deepStrictEqual(svg.querySelector(".node title").textContent, "a");
       assert.deepStrictEqual(svg.querySelector(".edge title").textContent, "a->b");
+    });
+
+    it("renders default node label", function() {
+      const svg = viz.renderSVGElement(`graph {
+        a[id=a]
+        b[id=b, label=test]
+      }`);
+
+      assert.deepStrictEqual(svg.querySelector("#a text").textContent, "a");
+      assert.deepStrictEqual(svg.querySelector("#b text").textContent, "test");
     });
 
     it("uses a trusted type policy if present", function() {

--- a/packages/viz/test/render.test.js
+++ b/packages/viz/test/render.test.js
@@ -89,53 +89,6 @@ describe("Viz", function() {
       });
     });
 
-    it("accepts default attributes", function() {
-      const result = viz.render("graph {}", {
-        graphAttributes: {
-          a: 123
-        },
-        nodeAttributes: {
-          b: false
-        },
-        edgeAttributes: {
-          c: "test"
-        }
-      });
-
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `graph {
-	graph [a=123,
-		bb="0,0,0,0"
-	];
-	node [b=false,
-		label="\\N"
-	];
-	edge [c=test];
-}
-`,
-        errors: []
-      });
-    });
-
-    it("default attribute values can be html strings", function() {
-      const result = viz.render("graph {}", {
-        nodeAttributes: {
-          label: { html: "<b>test</b>" }
-        }
-      });
-
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `graph {
-	graph [bb="0,0,0,0"];
-	node [label=<<b>test</b>>];
-}
-`,
-        errors: []
-      });
-    });
-
     it("returns an error for empty input", function() {
       const result = viz.render("");
 
@@ -291,27 +244,6 @@ stop
           { level: "warning", message: "Could not parse \"_background\" attribute in graph %1" },
           { level: "warning", message: "  \"123\"" }
         ]
-      });
-    });
-
-    it("the graph is read with the default node label set", function() {
-      const result = viz.render("graph { a; b[label=test] }");
-
-      assert.deepStrictEqual(result, {
-        status: "success",
-        output: `graph {
-	graph [bb="0,0,126,36"];
-	node [label="\\N"];
-	a	[height=0.5,
-		pos="27,18",
-		width=0.75];
-	b	[height=0.5,
-		label=test,
-		pos="99,18",
-		width=0.75];
-}
-`,
-        errors: []
       });
     });
 


### PR DESCRIPTION
Previously, default attributes were loaded in a way similar to the `dot` command-line, but that doesn't seem to have actually worked in practice. It appears to have only worked if none of the default attributes were already used, and the tests I wrote didn't properly exercise the cases users would actually care about, like the color of nodes, etc.

This changes the default attribute functions to apply the requested defaults after the graph is read, if the given attribute is not present on whatever object. The graph object reading routine also had to be adjusted to apply the default attributes for graphs and subgraphs after creating graphviz objects.

I added some tests that explicitly test default attributes with SVG rendering, (and rewrote some others to do that) since those are more relevant than DOT rendering and also easier to write.

See #380.