### PR TITLE
Don't leave valid images around if there was an invalid image (#388)

### DIFF
--- a/packages/viz/src/wrapper.js
+++ b/packages/viz/src/wrapper.js
@@ -137,7 +137,7 @@ function createImageFiles(module, images) {
     return [];
   }
 
-  return images.map(image => {
+  for (const image of images) {
     if (typeof image.name !== "string") {
       throw new Error("image name must be a string");
     } else if (typeof image.width !== "number" && typeof image.width !== "string") {
@@ -145,7 +145,9 @@ function createImageFiles(module, images) {
     } else if (typeof image.height !== "number" && typeof image.height !== "string") {
       throw new Error("image height must be a number or string");
     }
+  }
 
+  return images.map(image => {
     const path = module.PATH.join("/", image.name);
     const data = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${image.width}" height="${image.height}"></svg>

--- a/packages/viz/test/images.test.js
+++ b/packages/viz/test/images.test.js
@@ -8,7 +8,7 @@ describe("Viz", function() {
     viz = await VizPackage.instance();
   });
 
-  describe("render", function() {
+  describe("images", function() {
     it("accepts an images option", function() {
       const result = viz.render("graph { a[image=\"test.png\"] }", {
         images: [
@@ -107,6 +107,24 @@ describe("Viz", function() {
       assert.throws(() => viz.render("...", { images: [{ name: "test.png", height: 123 }] }), /image width/);
       assert.throws(() => viz.render("...", { images: [{ name: "test.png", width: 456 }] }), /image height/);
       assert.throws(() => viz.render("...", { images: ["test.png"] }), /image name/);
+    });
+
+    it("does not leave valid images in place when an error was previously thrown for an invalid image", function() {
+      assert.throws(() => {
+        viz.render("graph { a[image=\"http://example.com/test.png\"] }", {
+          images: [
+            { name: "http://example.com/test.png", width: 300, height: 200 },
+            { name: "http://example.com/test2.png" }
+          ]
+        });
+      });
+
+      const result = viz.render("graph { a[image=\"http://example.com/test.png\"] }");
+
+      assert.deepStrictEqual(result.errors, [
+        { level: "warning", message: `No such file or directory while opening http://example.com/test.png` },
+        { level: "warning", message: `No or improper image="http://example.com/test.png" for node "a"` }
+      ]);
     });
   });
 });


### PR DESCRIPTION
The wrapper code validates the image option, throwing if any of its items are invalid. However, it previously did this as part of a loop creating the images, which meant that the paths of images that were created would never reach the cleanup function, and would remain in the virtual filesystem.

This moves the validation step to before the file creation step so that no image files are created if the images option contains invalid items.